### PR TITLE
Fix links in table of contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@
 
   - Learning about TESSERA
       - [Introduction](#introduction)
-      - [Papers](#Papers)
+      - [Papers](#papers)
       - [Podcast](https://www.satellite-image-deep-learning.com/p/tessera-a-temporal-foundation-model)
       - [Presentations](#presentations)
-      - [License](#License)
+      - [License](#license)
   - Using TESSERA
       - [Acceptable Use Policy](https://svr-sk818-web.cl.cam.ac.uk/tessera/index.php/Acceptable_use_policy)
-      - [Accessing Precomputed Embeddings](#global-embeddings-access)
+      - [Accessing Precomputed Embeddings](#accessing-embeddings-using-geotessera-recommended)
       - [Creating Your Own Embeddings](#creating-your-own-embeddings)
       - [Downstream Tasks](#downstream-tasks)
-      - [TESSERA Users Group](tessera-users-group)
+      - [TESSERA Users Group](#tessera-users-group)
   - Additional information
       - [Team](#team)
       - [Contact](#contact)


### PR DESCRIPTION
1. The links "tessera-users-group" and "#global-embeddings-access" were faulty.

2. Markdown links should be lowercase, so I changed "#Papers" -> "#papers". Github could somehow interpret it, but other Markdown viewers struggle.

Tip: If using vscode, I can recommend the "yzhang.markdown-all-in-one" extension, that can automatically create configurable table of contents.
