### PR TITLE
V1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ first_three_band.png
 pca_three_band.png
 core
 infer_v1_1.slurm
+scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ tessera_preprocessing/s1_s2_downloader_my.sh
 **/*.aux.xml
 *.log
 *.json
+*.err
+*.out
 tessera_data_preprocessing/d_pixel_processing_logs
 tessera_data_preprocessing/_batch_submit.sh
 continuous_*.sh
@@ -54,3 +56,5 @@ tessera_infer/profiler/chat_history.txt
 chat_history.txt
 first_three_band.png
 pca_three_band.png
+core
+infer_v1_1.slurm

--- a/README.md
+++ b/README.md
@@ -373,12 +373,9 @@ The QAT pipeline outputs quantized embeddings as **int8 + scales**:
 
 ### v1.1 QAT Model Weight (latest, recommended)
 
-TESSERA **v1.1** is a new pretrained QAT checkpoint. Compared to the v1.0 QAT
-checkpoint above, v1.1 brings:
+TESSERA **v1.1** is a new pretrained QAT model that improves on the v1.0 QAT
+checkpoint above. Compared to v1.0, v1.1 brings:
 
-- **Three separate backbones** for Sentinel-2, Sentinel-1 ascending, and Sentinel-1
-  descending (instead of a merged S1 encoder), giving the model a clearer view of
-  each modality's acquisition geometry.
 - **Wider encoder** (`latent_dim=192`, transformer `d_model=768`) and an **MLP
   `dim_reducer`** (Linear → LayerNorm → ReLU → Dropout → Linear) that outputs a
   192-D representation; the first 128 dims are saved for downstream use.
@@ -387,41 +384,82 @@ checkpoint above, v1.1 brings:
   counts are bucketised to a configurable list `num_obs_checkpoints` (default: every
   multiple of 8 from 8 to 256, i.e. `[8, 16, 24, 32, ..., 248, 256]`) so pixels
   sharing the same bucket can be batched together.
+- **Per-modality S1 normalisation.** S1 ascending and descending are normalised
+  with their OWN per-band mean/std, then concatenated time-wise into a single
+  merged S1 stream that feeds one S1 backbone (same two-backbone topology as
+  v1.0).
 
-**Download** the checkpoint `best_model_fsdp_20260408_154724.pt` from
-[Google Drive](https://drive.google.com/file/d/1hxUr4j9daoNt9pxJZc6X6569bdpYUTAb/view?usp=sharing)
-(HuggingFace mirror coming soon) and place it into `tessera_infer_QAT/checkpoints`:
+#### Two data sources × two checkpoint flavours
+
+v1.1 ships **two checkpoints per preprocessing source × two flavours each**:
+
+- **encoder-only** (~250 MB, default for inference) — contains exactly the
+  weights consumed by the inference graph (`s2_backbone`, `s1_backbone`,
+  `dim_reducer`). This is what you almost always want.
+- **full** (~10 GB) — encoder + projector + optimiser/scaler state. Only
+  download this if you intend to **fine-tune** v1.1 on your own data.
+
+Each checkpoint was trained with its own normalisation statistics, so **you
+must pair the right checkpoint with the right `data_source` setting in the
+config** (otherwise the input distribution is silently mis-shifted and embedding
+quality collapses):
+
+| Data source | Encoder-only (recommended, ~221 MB)            | Full (fine-tune, ~10 GB)                         | `data_source` value |
+| ----------- | ----------------------------------------------- | ------------------------------------------------- | ------------------- |
+| Microsoft Planetary Computer (S2 L2A + S1 RTC)   | [`tessera_v1_1_mpc_encoder.pt`](https://drive.google.com/file/d/1t-gfTxi3Hg_uJXpJ9etROCRgKt2myfJ2/view?usp=drive_link) | [`tessera_v1_1_mpc_full.pt`](https://drive.google.com/file/d/1pBXlBscBedlh0CkfD6vW277XkN8WevZA/view?usp=sharing) | `"mpc"` |
+| AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1) | [`tessera_v1_1_aws_encoder.pt`](https://drive.google.com/file/d/1taLxwJOId-pfqUafEOCf5zDPXA7kzdyu/view?usp=sharing) | [`tessera_v1_1_aws_full.pt`](https://drive.google.com/file/d/1xa8P6dFuqcdUW1c3-07_-0-KHIrSZAci/view?usp=sharing) | `"aws"` |
+
+Per-source normalisation statistics are kept in
+`tessera_infer_QAT/src/datasets/v1_1_norm_stats.py`. The config field
+`data_source` (default `"mpc"`) selects which set is used at inference time.
+
+The inference loader uses `strict=False` and silently ignores keys that
+aren't part of the inference graph, so a *full* checkpoint will also work in
+the same command — it's just ~45× larger to download. (A HuggingFace mirror
+will follow once the Drive links stabilise.)
+
+**Download** one (or more) of the four checkpoints above and place into
+`tessera_infer_QAT/checkpoints`:
 
 ```
 tessera_infer_QAT
  ┣ checkpoints
- ┃   ┗ best_model_fsdp_20260408_154724.pt
+ ┃   ┣ tessera_v1_1_mpc_encoder.pt          # MPC, encoder-only (default)
+ ┃   ┣ tessera_v1_1_aws_encoder.pt          # AWS, encoder-only
+ ┃   ┣ tessera_v1_1_mpc_full.pt             # MPC, full (fine-tune only)
+ ┃   ┗ tessera_v1_1_aws_full.pt             # AWS, full (fine-tune only)
  ┣ configs
- ┃   ┗ v1_1_infer_config.py
+ ┃   ┗ v1_1_infer_config.py                 # set data_source = "mpc" or "aws"
  ┣ src
- ┃   ┗ infer_v1_1.py
+ ┃   ┣ infer_v1_1.py
+ ┃   ┗ datasets
+ ┃       └─ v1_1_norm_stats.py
  ┗ visualize_embedding_v1_1.py
 ```
 
-**Run inference** on a single preprocessed tile (a folder produced by the
-preprocessing pipeline containing `bands.npy`, `masks.npy`, `doys.npy`,
+**Run inference** on a single preprocessed tile (a folder produced by
+`tessera_preprocessing` containing `bands.npy`, `masks.npy`, `doys.npy`,
 `sar_ascending.npy`, `sar_ascending_doy.npy`, `sar_descending.npy`,
 `sar_descending_doy.npy`):
 
 ```bash
 cd tessera_infer_QAT
+
+# MPC inference (default; encoder-only ckp is enough)
 python src/infer_v1_1.py \
     --config          configs/v1_1_infer_config.py \
-    --checkpoint_path checkpoints/best_model_fsdp_20260408_154724.pt \
+    --checkpoint_path checkpoints/tessera_v1_1_mpc_encoder.pt \
     --tile_path       /absolute/path/to/retiled_d_pixel/0_3500_500_4000 \
-    --output_dir      /absolute/path/to/representation_retiled_v1_1 \
-    --output_prefix   0_3500_500_4000
+    --output_dir      /absolute/path/to/representation_retiled_v1_1
 ```
 
-Adjust `num_obs_checkpoints` in `configs/v1_1_infer_config.py` to trade off
-between embedding quality and compute (fewer / smaller checkpoints = faster,
-more / larger = more temporal detail). For a Slurm cluster, see
-`tessera_infer_QAT/infer_v1_1.slurm` for a ready-to-edit template.
+For AWS data, pass `--data_source aws` and use the AWS encoder ckp:
+`--checkpoint_path checkpoints/tessera_v1_1_aws_encoder.pt`.
+
+Adjust `num_obs_checkpoints` to trade off between embedding quality and compute
+(fewer / smaller checkpoints = faster, more / larger = more temporal detail).
+For a Slurm cluster, see `tessera_infer_QAT/infer_v1_1.slurm` for a
+ready-to-edit template.
 
 **Output** files (same int8 + scales format as v1.0 QAT, with `_emb128_` naming):
 - `<prefix>_emb128_int8.npy`   — shape `(H, W, 128)`, dtype `int8`

--- a/README.md
+++ b/README.md
@@ -371,6 +371,67 @@ The QAT pipeline outputs quantized embeddings as **int8 + scales**:
 - `tile_name.npy`: int8 embedding tensor, shape `(H, W, 128)`
 - `tile_name_scales.npy`: float32 scale map, shape `(H, W)`
 
+### v1.1 QAT Model Weight (latest, recommended)
+
+TESSERA **v1.1** is a new pretrained QAT checkpoint. Compared to the v1.0 QAT
+checkpoint above, v1.1 brings:
+
+- **Three separate backbones** for Sentinel-2, Sentinel-1 ascending, and Sentinel-1
+  descending (instead of a merged S1 encoder), giving the model a clearer view of
+  each modality's acquisition geometry.
+- **Wider encoder** (`latent_dim=192`, transformer `d_model=768`) and an **MLP
+  `dim_reducer`** (Linear → LayerNorm → ReLU → Dropout → Linear) that outputs a
+  192-D representation; the first 128 dims are saved for downstream use.
+- **All-observation inference.** Unlike v1.0, which randomly samples a fixed 40
+  timesteps per pixel, v1.1 uses **every valid observation** per pixel. Observation
+  counts are bucketised to a configurable list `num_obs_checkpoints` (default: every
+  multiple of 8 from 8 to 256, i.e. `[8, 16, 24, 32, ..., 248, 256]`) so pixels
+  sharing the same bucket can be batched together.
+
+**Download** the checkpoint `best_model_fsdp_20260408_154724.pt` from
+[Google Drive](https://drive.google.com/file/d/1hxUr4j9daoNt9pxJZc6X6569bdpYUTAb/view?usp=sharing)
+(HuggingFace mirror coming soon) and place it into `tessera_infer_QAT/checkpoints`:
+
+```
+tessera_infer_QAT
+ ┣ checkpoints
+ ┃   ┗ best_model_fsdp_20260408_154724.pt
+ ┣ configs
+ ┃   ┗ v1_1_infer_config.py
+ ┣ src
+ ┃   ┗ infer_v1_1.py
+ ┗ visualize_embedding_v1_1.py
+```
+
+**Run inference** on a single preprocessed tile (a folder produced by the
+preprocessing pipeline containing `bands.npy`, `masks.npy`, `doys.npy`,
+`sar_ascending.npy`, `sar_ascending_doy.npy`, `sar_descending.npy`,
+`sar_descending_doy.npy`):
+
+```bash
+cd tessera_infer_QAT
+python src/infer_v1_1.py \
+    --config          configs/v1_1_infer_config.py \
+    --checkpoint_path checkpoints/best_model_fsdp_20260408_154724.pt \
+    --tile_path       /absolute/path/to/retiled_d_pixel/0_3500_500_4000 \
+    --output_dir      /absolute/path/to/representation_retiled_v1_1 \
+    --output_prefix   0_3500_500_4000
+```
+
+Adjust `num_obs_checkpoints` in `configs/v1_1_infer_config.py` to trade off
+between embedding quality and compute (fewer / smaller checkpoints = faster,
+more / larger = more temporal detail). For a Slurm cluster, see
+`tessera_infer_QAT/infer_v1_1.slurm` for a ready-to-edit template.
+
+**Output** files (same int8 + scales format as v1.0 QAT, with `_emb128_` naming):
+- `<prefix>_emb128_int8.npy`   — shape `(H, W, 128)`, dtype `int8`
+- `<prefix>_emb128_scales.npy` — shape `(H, W)`,      dtype `float32`
+
+Reconstruct fp32 embeddings with
+`fp32 = int8.astype(np.float32) * scales[..., None]`. A helper script
+`visualize_embedding_v1_1.py` dequantises the output and saves a first-3-dim RGB
+plus a PCA-3 RGB for quick visual inspection.
+
 ### Configure Bash Script
 
 To simplify inference configuration, we provide `tessera_infer/infer_all_tiles.sh`. You only need to edit a few parameters:

--- a/README.md
+++ b/README.md
@@ -407,7 +407,21 @@ quality collapses):
 | Data source | Encoder-only (recommended, ~221 MB)            | Full (fine-tune, ~10 GB)                         | `data_source` value |
 | ----------- | ----------------------------------------------- | ------------------------------------------------- | ------------------- |
 | Microsoft Planetary Computer (S2 L2A + S1 RTC)   | [`tessera_v1_1_mpc_encoder.pt`](https://drive.google.com/file/d/1t-gfTxi3Hg_uJXpJ9etROCRgKt2myfJ2/view?usp=drive_link) | [`tessera_v1_1_mpc_full.pt`](https://drive.google.com/file/d/1pBXlBscBedlh0CkfD6vW277XkN8WevZA/view?usp=sharing) | `"mpc"` |
-| AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1) | [`tessera_v1_1_aws_encoder.pt`](https://drive.google.com/file/d/1taLxwJOId-pfqUafEOCf5zDPXA7kzdyu/view?usp=sharing) | [`tessera_v1_1_aws_full.pt`](https://drive.google.com/file/d/1xa8P6dFuqcdUW1c3-07_-0-KHIrSZAci/view?usp=sharing) | `"aws"` |
+| AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1) | [`tessera_v1_1_aws_encoder.pt`](https://drive.google.com/file/d/1taLxwJOId-pfqUafEOCf5zDPXA7kzdyu/view?usp=sharing) ⚠ | [`tessera_v1_1_aws_full.pt`](https://drive.google.com/file/d/1xa8P6dFuqcdUW1c3-07_-0-KHIrSZAci/view?usp=sharing) ⚠ | `"aws"` |
+
+> ⚠ **AWS checkpoint compatibility note (post-fix).** The AWS v1.1 checkpoints
+> currently published were trained on output from a preprocessing build that
+> double-applied the PB-04.00 BOA_ADD_OFFSET to AWS / Earth-search Sentinel-2
+> data (Earth-search ships COGs with the +1000 offset already removed; the old
+> `harmonize_arr` subtracted it again, producing values ~1000 too low for
+> post-2022-01-25 acquisitions on bands ≥1000). The bug is fixed in
+> `tessera_preprocessing/s2_fast_processor.py` (commit guarded by
+> `DATA_SOURCE != "aws"`), but the AWS norm stats in
+> `tessera_infer_QAT/src/datasets/v1_1_norm_stats.py` and the AWS checkpoints
+> still reflect the OLD (buggy) distribution. Until the AWS model is
+> re-pretrained on the corrected preprocessing output, AWS inference
+> end-to-end is **not yet recommended** — use the MPC checkpoints. (MPC was
+> always handled correctly and is unaffected.)
 
 Per-source normalisation statistics are kept in
 `tessera_infer_QAT/src/datasets/v1_1_norm_stats.py`. The config field

--- a/README.md
+++ b/README.md
@@ -407,21 +407,15 @@ quality collapses):
 | Data source | Encoder-only (recommended, ~221 MB)            | Full (fine-tune, ~10 GB)                         | `data_source` value |
 | ----------- | ----------------------------------------------- | ------------------------------------------------- | ------------------- |
 | Microsoft Planetary Computer (S2 L2A + S1 RTC)   | [`tessera_v1_1_mpc_encoder.pt`](https://drive.google.com/file/d/1t-gfTxi3Hg_uJXpJ9etROCRgKt2myfJ2/view?usp=drive_link) | [`tessera_v1_1_mpc_full.pt`](https://drive.google.com/file/d/1pBXlBscBedlh0CkfD6vW277XkN8WevZA/view?usp=sharing) | `"mpc"` |
-| AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1) | [`tessera_v1_1_aws_encoder.pt`](https://drive.google.com/file/d/1taLxwJOId-pfqUafEOCf5zDPXA7kzdyu/view?usp=sharing) ⚠ | [`tessera_v1_1_aws_full.pt`](https://drive.google.com/file/d/1xa8P6dFuqcdUW1c3-07_-0-KHIrSZAci/view?usp=sharing) ⚠ | `"aws"` |
+| AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1) | [`tessera_v1_1_aws_encoder.pt`](https://drive.google.com/file/d/1taLxwJOId-pfqUafEOCf5zDPXA7kzdyu/view?usp=sharing) | [`tessera_v1_1_aws_full.pt`](https://drive.google.com/file/d/1GqtqaAPaJhyZzQxxjtnZOqG3dq5JQzMK/view?usp=sharing) | `"aws"` |
 
-> ⚠ **AWS checkpoint compatibility note (post-fix).** The AWS v1.1 checkpoints
-> currently published were trained on output from a preprocessing build that
-> double-applied the PB-04.00 BOA_ADD_OFFSET to AWS / Earth-search Sentinel-2
-> data (Earth-search ships COGs with the +1000 offset already removed; the old
-> `harmonize_arr` subtracted it again, producing values ~1000 too low for
-> post-2022-01-25 acquisitions on bands ≥1000). The bug is fixed in
-> `tessera_preprocessing/s2_fast_processor.py` (commit guarded by
-> `DATA_SOURCE != "aws"`), but the AWS norm stats in
-> `tessera_infer_QAT/src/datasets/v1_1_norm_stats.py` and the AWS checkpoints
-> still reflect the OLD (buggy) distribution. Until the AWS model is
-> re-pretrained on the corrected preprocessing output, AWS inference
-> end-to-end is **not yet recommended** — use the MPC checkpoints. (MPC was
-> always handled correctly and is unaffected.)
+> **AWS checkpoint update (2026-05-03).** The AWS v1.1 checkpoint was
+> retrained on data collected with the corrected preprocessing pipeline
+> (see `tessera_preprocessing/s2_fast_processor.py::harmonize_arr`, which
+> previously double-applied the PB-04.00 BOA_ADD_OFFSET on AWS / Earth-search
+> Sentinel-2 data). The AWS row in
+> `tessera_infer_QAT/src/datasets/v1_1_norm_stats.py` has been refreshed
+> against the new pretraining distribution.
 
 Per-source normalisation statistics are kept in
 `tessera_infer_QAT/src/datasets/v1_1_norm_stats.py`. The config field

--- a/tessera_infer_QAT/configs/v1_1_infer_config.py
+++ b/tessera_infer_QAT/configs/v1_1_infer_config.py
@@ -1,0 +1,55 @@
+# configs/v1_1_infer_config.py
+#
+# Tessera v1.1 (QAT) inference config. Follows the same conventions as the v1.0
+# `multi_tile_infer_config.py`: model- and runtime-only. Input data paths are NOT
+# specified here — they are passed to the inference entry point via CLI
+# (`--tile_path <dir>`), where `<dir>` is a standard Tessera preprocessing tile
+# layout containing:
+#     bands.npy, masks.npy, doys.npy,
+#     sar_ascending.npy,  sar_ascending_doy.npy,
+#     sar_descending.npy, sar_descending_doy.npy
+
+config = {
+    # ---------------- runtime ----------------
+    "batch_size": 1024,
+    "num_workers": 8,
+    "use_bf16": True,
+    "apply_amp": True,
+    "log_interval_steps": 20,
+
+    # ---------------- model (v1.1) ----------------
+    "fusion_method": "concat",        # v1.1 pretraining uses concat fusion
+    "latent_dim": 192,                # encoder width; transformer d_model = latent_dim * 4
+    "representation_dim": 192,        # post dim_reducer representation width
+    "save_embedding_dim": 128,        # saved embedding width (capped at 128)
+
+    # Transformer settings (shared across the three backbones)
+    "s2_num_heads": 4,
+    "s2_num_layers": 4,
+    "s2_dim_feedforward": 2048,
+    "s1_num_heads": 4,
+    "s1_num_layers": 4,
+    "s1_dim_feedforward": 2048,
+
+    # Modalities — v1.1 uses three separate backbones (S2, S1-asc, S1-desc)
+    "use_s2": True,
+    "use_s1": True,
+    "split_s1_modalities": True,
+    "disable_s1_ascending": False,
+
+    # Quantisation
+    "apply_qat_representation": True,   # save int8 + per-pixel scale
+    "qat_representation_bits": 8,
+
+    # ---------------- v1.1 observation selection ----------------
+    # v1.1 keeps EVERY valid observation per pixel (no fixed `sample_size_s2/s1`
+    # as in v1.0). Observation counts are bucketised to the next entry in
+    # `num_obs_checkpoints`; pixels sharing a bucket are batched together so
+    # Transformer inputs within a batch have uniform sequence length.
+    # Lower / fewer checkpoints = faster, coarser temporal resolution.
+    # Higher / more    checkpoints = slower, richer temporal resolution.
+    "num_obs_checkpoints": [8, 16, 24, 32, 40, 48, 56, 64,
+                            72, 80, 88, 96, 104, 112, 120, 128,
+                            136, 144, 152, 160, 168, 176, 184, 192,
+                            200, 208, 216, 224, 232, 240, 248, 256],
+}

--- a/tessera_infer_QAT/configs/v1_1_infer_config.py
+++ b/tessera_infer_QAT/configs/v1_1_infer_config.py
@@ -8,6 +8,17 @@
 #     bands.npy, masks.npy, doys.npy,
 #     sar_ascending.npy,  sar_ascending_doy.npy,
 #     sar_descending.npy, sar_descending_doy.npy
+#
+# v1.1 ships TWO checkpoints, one per data source. Each has its OWN per-band
+# normalisation stats — pick the matching `data_source` below or you'll feed
+# garbage into the model.
+#
+#   data_source = "mpc"  -> Microsoft Planetary Computer (Sentinel-2 L2A + Sentinel-1 RTC)
+#                           checkpoint: best_model_fsdp_20260425_133615.pt
+#   data_source = "aws"  -> AWS Open Data (Earth-search S2 L2A + ASF OPERA RTC-S1)
+#                           checkpoint: best_model_fsdp_20260425_202039.pt
+#
+# Stats live in `src/datasets/v1_1_norm_stats.py`.
 
 config = {
     # ---------------- runtime ----------------
@@ -17,13 +28,16 @@ config = {
     "apply_amp": True,
     "log_interval_steps": 20,
 
+    # ---------------- data source ----------------
+    "data_source": "mpc",   # "mpc" or "aws" — MUST match the checkpoint you load.
+
     # ---------------- model (v1.1) ----------------
     "fusion_method": "concat",        # v1.1 pretraining uses concat fusion
     "latent_dim": 192,                # encoder width; transformer d_model = latent_dim * 4
     "representation_dim": 192,        # post dim_reducer representation width
     "save_embedding_dim": 128,        # saved embedding width (capped at 128)
 
-    # Transformer settings (shared across the three backbones)
+    # Transformer settings (shared across the two backbones)
     "s2_num_heads": 4,
     "s2_num_layers": 4,
     "s2_dim_feedforward": 2048,
@@ -31,10 +45,10 @@ config = {
     "s1_num_layers": 4,
     "s1_dim_feedforward": 2048,
 
-    # Modalities — v1.1 uses three separate backbones (S2, S1-asc, S1-desc)
+    # Modalities — this revision of v1.1 uses a single merged S1 backbone.
     "use_s2": True,
     "use_s1": True,
-    "split_s1_modalities": True,
+    "split_s1_modalities": False,       # MUST be False for the new v1.1 ckps
     "disable_s1_ascending": False,
 
     # Quantisation
@@ -44,8 +58,8 @@ config = {
     # ---------------- v1.1 observation selection ----------------
     # v1.1 keeps EVERY valid observation per pixel (no fixed `sample_size_s2/s1`
     # as in v1.0). Observation counts are bucketised to the next entry in
-    # `num_obs_checkpoints`; pixels sharing a bucket are batched together so
-    # Transformer inputs within a batch have uniform sequence length.
+    # `num_obs_checkpoints`; pixels sharing a (s2_bin, s1_bin) bucket are batched
+    # together so Transformer inputs within a batch have uniform sequence length.
     # Lower / fewer checkpoints = faster, coarser temporal resolution.
     # Higher / more    checkpoints = slower, richer temporal resolution.
     "num_obs_checkpoints": [8, 16, 24, 32, 40, 48, 56, 64,

--- a/tessera_infer_QAT/src/datasets/ssl_dataset_v1_1.py
+++ b/tessera_infer_QAT/src/datasets/ssl_dataset_v1_1.py
@@ -1,0 +1,212 @@
+# src/datasets/ssl_dataset_v1_1.py
+#
+# Tessera v1.1 inference dataset with bucketised "all observations" resampling.
+#
+# Unlike v1.0 (which draws a fixed sample_size_s2/s1 random subset per pixel), v1.1
+# preserves every valid observation. To keep batches rectangular the observation
+# count is bucketised: for each pixel we pick the smallest `num_obs_checkpoints`
+# entry >= actual_valid_count, capped at the largest checkpoint. Pixels sharing the
+# same (s2_bin, s1a_bin, s1d_bin) key are batched together by the custom batch
+# sampler (see bucket_sampler.py).
+
+import logging
+import os
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from datasets.ssl_dataset import S1_BAND_MEAN, S1_BAND_STD, S2_BAND_MEAN, S2_BAND_STD
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+def build_resample_indices(valid_len: int, target_size: int) -> np.ndarray:
+    """Deterministic index vector that resamples `valid_len` observations to `target_size`.
+
+    - target_size == valid_len: identity
+    - target_size <  valid_len: evenly-spaced subsample (median element of each chunk)
+    - target_size >  valid_len: every original index is kept; extras are chosen at
+      evenly-spaced positions to fill the remainder (duplicates allowed).
+    """
+    valid_len = int(valid_len)
+    target_size = int(target_size)
+    if valid_len <= 0:
+        return np.array([], dtype=np.int64)
+    if target_size == valid_len:
+        return np.arange(valid_len, dtype=np.int64)
+    if target_size < valid_len:
+        chunks = np.array_split(np.arange(valid_len), target_size)
+        return np.array([c[len(c) // 2] for c in chunks if len(c) > 0], dtype=np.int64)
+    extra = target_size - valid_len
+    anchors = np.linspace(0, valid_len - 1, num=extra + 2, dtype=np.float64)[1:-1]
+    extras = np.rint(anchors).astype(np.int64)
+    extras = np.clip(extras, 0, valid_len - 1)
+    return np.concatenate([np.arange(valid_len, dtype=np.int64), extras], axis=0)
+
+
+def _resolve_paths(tile_path):
+    """Standard Tessera preprocessing tile layout."""
+    return (
+        os.path.join(tile_path, "bands.npy"),
+        os.path.join(tile_path, "masks.npy"),
+        os.path.join(tile_path, "doys.npy"),
+        os.path.join(tile_path, "sar_ascending.npy"),
+        os.path.join(tile_path, "sar_ascending_doy.npy"),
+        os.path.join(tile_path, "sar_descending.npy"),
+        os.path.join(tile_path, "sar_descending_doy.npy"),
+    )
+
+
+class SingleTileInferenceDatasetV1_1(Dataset):
+    """
+    Per-pixel iteration with v1.1 bucketised all-observation resampling.
+
+    __getitem__ returns a dict:
+        s2_bands:  (s2_target, 11)   float32 (standardised S2 bands + doy)
+        s1a_bands: (s1a_target, 3)   float32 (standardised S1-asc bands + doy)
+        s1d_bands: (s1d_target, 3)   float32 (standardised S1-desc bands + doy)
+        i, j:      pixel coordinates
+        global_idx: flat pixel index (H*W convention, row-major)
+        bin_key:   (s2_target, s1a_target, s1d_target) for the custom batch sampler
+    """
+
+    def __init__(self, tile_path, config):
+        super().__init__()
+        self.config = config
+        self.tile_path = tile_path
+
+        self.use_s2 = bool(config.get("use_s2", True))
+        self.use_s1 = bool(config.get("use_s1", True))
+        self.split_s1 = bool(config.get("split_s1_modalities", True))
+        self.disable_s1_asc = bool(config.get("disable_s1_ascending", False))
+
+        ckps = sorted({int(v) for v in config.get("num_obs_checkpoints", [8, 16, 32, 64, 128]) if int(v) > 0})
+        if not ckps:
+            raise ValueError("num_obs_checkpoints must contain positive integers.")
+        self.ckps = ckps
+        self.max_ckp = ckps[-1]
+
+        s2_b, s2_m, s2_d, s1a_b, s1a_d, s1d_b, s1d_d = _resolve_paths(tile_path)
+
+        # Memory-map the big arrays so we don't blow up RAM on a 459x518x94x10 volume.
+        self.s2_bands = np.load(s2_b, mmap_mode="r") if self.use_s2 else None
+        self.s2_masks = np.load(s2_m, mmap_mode="r") if self.use_s2 else None
+        self.s2_doys  = np.load(s2_d, mmap_mode="r") if self.use_s2 else None
+
+        if self.use_s1 and not self.disable_s1_asc:
+            self.s1a_bands = np.load(s1a_b, mmap_mode="r")
+            self.s1a_doys  = np.load(s1a_d, mmap_mode="r")
+        else:
+            self.s1a_bands = None
+            self.s1a_doys = None
+
+        if self.use_s1:
+            self.s1d_bands = np.load(s1d_b, mmap_mode="r")
+            self.s1d_doys  = np.load(s1d_d, mmap_mode="r")
+        else:
+            self.s1d_bands = None
+            self.s1d_doys = None
+
+        # Image shape from whichever modality is available.
+        self.H, self.W = self._infer_hw()
+        self.num_pixels = self.H * self.W
+        coords = np.indices((self.H, self.W)).reshape(2, -1).T
+        self.pixel_coords = coords.astype(np.int64, copy=False)
+
+        # Precompute valid-count per pixel per modality → bucket key per pixel.
+        self.pixel_bin_keys, self.bins_to_indices = self._build_bin_keys()
+
+        logging.info(
+            f"[SingleTileInferenceDatasetV1_1] H={self.H}, W={self.W}, "
+            f"pixels={self.num_pixels}, buckets={len(self.bins_to_indices)}"
+        )
+
+    def _infer_hw(self):
+        for arr in (self.s2_bands, self.s1d_bands, self.s1a_bands):
+            if arr is not None:
+                return int(arr.shape[1]), int(arr.shape[2])
+        raise ValueError("At least one modality must be enabled for inference.")
+
+    def _to_bin(self, n: int) -> int:
+        n = int(n)
+        for c in self.ckps:
+            if n <= c:
+                return c
+        return self.max_ckp
+
+    def _build_bin_keys(self):
+        s2_valid = np.zeros(self.num_pixels, dtype=np.int32)
+        s1a_valid = np.zeros(self.num_pixels, dtype=np.int32)
+        s1d_valid = np.zeros(self.num_pixels, dtype=np.int32)
+
+        if self.s2_masks is not None:
+            s2_valid = self.s2_masks.reshape(self.s2_masks.shape[0], -1).sum(axis=0).astype(np.int32, copy=False)
+
+        if self.s1a_bands is not None and self.s1a_bands.shape[0] > 0:
+            flat = np.any(self.s1a_bands != 0, axis=-1).reshape(self.s1a_bands.shape[0], -1)
+            s1a_valid = flat.sum(axis=0).astype(np.int32, copy=False)
+        if self.s1d_bands is not None and self.s1d_bands.shape[0] > 0:
+            flat = np.any(self.s1d_bands != 0, axis=-1).reshape(self.s1d_bands.shape[0], -1)
+            s1d_valid = flat.sum(axis=0).astype(np.int32, copy=False)
+
+        keys = np.empty(self.num_pixels, dtype=np.dtype([("s2", np.int32), ("s1a", np.int32), ("s1d", np.int32)]))
+        bins = {}
+        for p in range(self.num_pixels):
+            k = (self._to_bin(s2_valid[p]), self._to_bin(s1a_valid[p]), self._to_bin(s1d_valid[p]))
+            keys[p] = k
+            bins.setdefault(k, []).append(p)
+        return keys, bins
+
+    # ------------------------------------------------------------------
+    # __len__ / __getitem__
+    # ------------------------------------------------------------------
+
+    def __len__(self):
+        return self.num_pixels
+
+    def _sample_s2(self, i, j, target):
+        bands = self.s2_bands[:, i, j, :]
+        masks = self.s2_masks[:, i, j]
+        valid = np.nonzero(masks)[0]
+        if len(valid) == 0:
+            return np.zeros((target, bands.shape[1] + 1), dtype=np.float32)
+        idx_local = build_resample_indices(len(valid), target)
+        real = valid[idx_local]
+        sub_b = bands[real].astype(np.float32, copy=False)
+        sub_d = np.asarray(self.s2_doys)[real]
+        sub_b = (sub_b - S2_BAND_MEAN) / (S2_BAND_STD + 1e-9)
+        return np.hstack([sub_b, sub_d.reshape(-1, 1)]).astype(np.float32, copy=False)
+
+    def _sample_s1_stream(self, bands_arr, doys_arr, i, j, target):
+        if bands_arr is None or bands_arr.shape[0] == 0:
+            return np.zeros((target, 3), dtype=np.float32)
+        stream = bands_arr[:, i, j, :]
+        valid = np.nonzero(np.any(stream != 0, axis=-1))[0]
+        if len(valid) == 0:
+            return np.zeros((target, 3), dtype=np.float32)
+        idx_local = build_resample_indices(len(valid), target)
+        real = valid[idx_local]
+        sub_b = stream[real].astype(np.float32, copy=False)
+        sub_d = np.asarray(doys_arr)[real]
+        sub_b = (sub_b - S1_BAND_MEAN) / (S1_BAND_STD + 1e-9)
+        return np.hstack([sub_b, sub_d.reshape(-1, 1)]).astype(np.float32, copy=False)
+
+    def __getitem__(self, idx):
+        i, j = self.pixel_coords[idx]
+        bin_key = self.pixel_bin_keys[idx]
+        s2_t, s1a_t, s1d_t = int(bin_key["s2"]), int(bin_key["s1a"]), int(bin_key["s1d"])
+
+        s2 = self._sample_s2(i, j, s2_t) if self.use_s2 else np.zeros((0, 11), dtype=np.float32)
+        s1a = self._sample_s1_stream(self.s1a_bands, self.s1a_doys, i, j, s1a_t) if self.use_s1 else np.zeros((0, 3), dtype=np.float32)
+        s1d = self._sample_s1_stream(self.s1d_bands, self.s1d_doys, i, j, s1d_t) if self.use_s1 else np.zeros((0, 3), dtype=np.float32)
+
+        return {
+            "s2": torch.from_numpy(s2),
+            "s1a": torch.from_numpy(s1a),
+            "s1d": torch.from_numpy(s1d),
+            "i": int(i),
+            "j": int(j),
+            "global_idx": int(i) * self.W + int(j),
+            "bin_key": (s2_t, s1a_t, s1d_t),
+        }

--- a/tessera_infer_QAT/src/datasets/ssl_dataset_v1_1.py
+++ b/tessera_infer_QAT/src/datasets/ssl_dataset_v1_1.py
@@ -2,12 +2,15 @@
 #
 # Tessera v1.1 inference dataset with bucketised "all observations" resampling.
 #
-# Unlike v1.0 (which draws a fixed sample_size_s2/s1 random subset per pixel), v1.1
-# preserves every valid observation. To keep batches rectangular the observation
-# count is bucketised: for each pixel we pick the smallest `num_obs_checkpoints`
-# entry >= actual_valid_count, capped at the largest checkpoint. Pixels sharing the
-# same (s2_bin, s1a_bin, s1d_bin) key are batched together by the custom batch
-# sampler (see bucket_sampler.py).
+# v1.1 architecture (this revision):
+#   - Two backbones: S2 + S1-merged (split_s1_modalities = False, matching v1.0).
+#   - S1 ascending / descending are concatenated time-wise into a single S1 stream,
+#     but each is normalised with its OWN mean/std (asc -> S1A stats, desc -> S1D
+#     stats) BEFORE concatenation. This matches v1.1 training preprocessing.
+#
+# v1.1 inference uses every valid observation per pixel; counts are bucketised to
+# the next entry in `num_obs_checkpoints`. Pixels sharing a (s2_bin, s1_bin) key
+# are batched together so attention sequences are rectangular.
 
 import logging
 import os
@@ -16,7 +19,7 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 
-from datasets.ssl_dataset import S1_BAND_MEAN, S1_BAND_STD, S2_BAND_MEAN, S2_BAND_STD
+from datasets.v1_1_norm_stats import get_stats
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
@@ -63,12 +66,12 @@ class SingleTileInferenceDatasetV1_1(Dataset):
     Per-pixel iteration with v1.1 bucketised all-observation resampling.
 
     __getitem__ returns a dict:
-        s2_bands:  (s2_target, 11)   float32 (standardised S2 bands + doy)
-        s1a_bands: (s1a_target, 3)   float32 (standardised S1-asc bands + doy)
-        s1d_bands: (s1d_target, 3)   float32 (standardised S1-desc bands + doy)
+        s2:        (s2_target, 11)   float32 (standardised S2 bands + doy)
+        s1:        (s1_target, 3)    float32 (S1-asc + S1-desc concatenated, each
+                                              normalised with its own per-modality stats)
         i, j:      pixel coordinates
-        global_idx: flat pixel index (H*W convention, row-major)
-        bin_key:   (s2_target, s1a_target, s1d_target) for the custom batch sampler
+        global_idx: flat pixel index (row-major H*W)
+        bin_key:   (s2_target, s1_target) for the custom batch sampler
     """
 
     def __init__(self, tile_path, config):
@@ -78,8 +81,16 @@ class SingleTileInferenceDatasetV1_1(Dataset):
 
         self.use_s2 = bool(config.get("use_s2", True))
         self.use_s1 = bool(config.get("use_s1", True))
-        self.split_s1 = bool(config.get("split_s1_modalities", True))
         self.disable_s1_asc = bool(config.get("disable_s1_ascending", False))
+
+        # v1.1 (this revision) requires merged S1 — guard against accidentally
+        # loading an older split-s1 ckp.
+        if bool(config.get("split_s1_modalities", False)):
+            raise ValueError(
+                "v1.1 inference (this revision) expects split_s1_modalities=False. "
+                "If you have an older split-S1 v1.1 checkpoint you need an older "
+                "snapshot of this code."
+            )
 
         ckps = sorted({int(v) for v in config.get("num_obs_checkpoints", [8, 16, 32, 64, 128]) if int(v) > 0})
         if not ckps:
@@ -87,9 +98,18 @@ class SingleTileInferenceDatasetV1_1(Dataset):
         self.ckps = ckps
         self.max_ckp = ckps[-1]
 
+        # Per-source normalisation stats (MPC vs AWS). Pick MUST match the ckp.
+        stats = get_stats(config.get("data_source", "mpc"))
+        self.s2_mean = stats["s2_mean"]
+        self.s2_std  = stats["s2_std"]
+        self.s1a_mean = stats["s1a_mean"]
+        self.s1a_std  = stats["s1a_std"]
+        self.s1d_mean = stats["s1d_mean"]
+        self.s1d_std  = stats["s1d_std"]
+
         s2_b, s2_m, s2_d, s1a_b, s1a_d, s1d_b, s1d_d = _resolve_paths(tile_path)
 
-        # Memory-map the big arrays so we don't blow up RAM on a 459x518x94x10 volume.
+        # Memory-map so we don't blow up RAM on a large (T, H, W, B) volume.
         self.s2_bands = np.load(s2_b, mmap_mode="r") if self.use_s2 else None
         self.s2_masks = np.load(s2_m, mmap_mode="r") if self.use_s2 else None
         self.s2_doys  = np.load(s2_d, mmap_mode="r") if self.use_s2 else None
@@ -114,12 +134,13 @@ class SingleTileInferenceDatasetV1_1(Dataset):
         coords = np.indices((self.H, self.W)).reshape(2, -1).T
         self.pixel_coords = coords.astype(np.int64, copy=False)
 
-        # Precompute valid-count per pixel per modality → bucket key per pixel.
+        # Precompute valid-count per pixel per modality → (s2_bin, s1_bin) per pixel.
         self.pixel_bin_keys, self.bins_to_indices = self._build_bin_keys()
 
         logging.info(
             f"[SingleTileInferenceDatasetV1_1] H={self.H}, W={self.W}, "
-            f"pixels={self.num_pixels}, buckets={len(self.bins_to_indices)}"
+            f"pixels={self.num_pixels}, buckets={len(self.bins_to_indices)}, "
+            f"data_source={config.get('data_source', 'mpc')}"
         )
 
     def _infer_hw(self):
@@ -137,23 +158,22 @@ class SingleTileInferenceDatasetV1_1(Dataset):
 
     def _build_bin_keys(self):
         s2_valid = np.zeros(self.num_pixels, dtype=np.int32)
-        s1a_valid = np.zeros(self.num_pixels, dtype=np.int32)
-        s1d_valid = np.zeros(self.num_pixels, dtype=np.int32)
+        s1_valid = np.zeros(self.num_pixels, dtype=np.int32)
 
         if self.s2_masks is not None:
             s2_valid = self.s2_masks.reshape(self.s2_masks.shape[0], -1).sum(axis=0).astype(np.int32, copy=False)
 
         if self.s1a_bands is not None and self.s1a_bands.shape[0] > 0:
-            flat = np.any(self.s1a_bands != 0, axis=-1).reshape(self.s1a_bands.shape[0], -1)
-            s1a_valid = flat.sum(axis=0).astype(np.int32, copy=False)
+            flat_a = np.any(self.s1a_bands != 0, axis=-1).reshape(self.s1a_bands.shape[0], -1)
+            s1_valid = s1_valid + flat_a.sum(axis=0).astype(np.int32, copy=False)
         if self.s1d_bands is not None and self.s1d_bands.shape[0] > 0:
-            flat = np.any(self.s1d_bands != 0, axis=-1).reshape(self.s1d_bands.shape[0], -1)
-            s1d_valid = flat.sum(axis=0).astype(np.int32, copy=False)
+            flat_d = np.any(self.s1d_bands != 0, axis=-1).reshape(self.s1d_bands.shape[0], -1)
+            s1_valid = s1_valid + flat_d.sum(axis=0).astype(np.int32, copy=False)
 
-        keys = np.empty(self.num_pixels, dtype=np.dtype([("s2", np.int32), ("s1a", np.int32), ("s1d", np.int32)]))
+        keys = np.empty(self.num_pixels, dtype=np.dtype([("s2", np.int32), ("s1", np.int32)]))
         bins = {}
         for p in range(self.num_pixels):
-            k = (self._to_bin(s2_valid[p]), self._to_bin(s1a_valid[p]), self._to_bin(s1d_valid[p]))
+            k = (self._to_bin(s2_valid[p]), self._to_bin(s1_valid[p]))
             keys[p] = k
             bins.setdefault(k, []).append(p)
         return keys, bins
@@ -175,38 +195,59 @@ class SingleTileInferenceDatasetV1_1(Dataset):
         real = valid[idx_local]
         sub_b = bands[real].astype(np.float32, copy=False)
         sub_d = np.asarray(self.s2_doys)[real]
-        sub_b = (sub_b - S2_BAND_MEAN) / (S2_BAND_STD + 1e-9)
+        sub_b = (sub_b - self.s2_mean) / (self.s2_std + 1e-9)
         return np.hstack([sub_b, sub_d.reshape(-1, 1)]).astype(np.float32, copy=False)
 
-    def _sample_s1_stream(self, bands_arr, doys_arr, i, j, target):
-        if bands_arr is None or bands_arr.shape[0] == 0:
+    def _sample_s1_merged(self, i, j, target):
+        """Concatenate asc+desc for pixel (i,j), each normalised with its own stats.
+
+        We collect valid asc rows, valid desc rows, normalise each block, then
+        concatenate (asc first, desc second) and resample to `target` length.
+        """
+        asc_b, asc_d = None, None
+        if self.s1a_bands is not None and self.s1a_bands.shape[0] > 0:
+            stream = self.s1a_bands[:, i, j, :]
+            valid = np.nonzero(np.any(stream != 0, axis=-1))[0]
+            if len(valid) > 0:
+                asc_b = stream[valid].astype(np.float32, copy=False)
+                asc_b = (asc_b - self.s1a_mean) / (self.s1a_std + 1e-9)
+                asc_d = np.asarray(self.s1a_doys)[valid].astype(np.float32, copy=False)
+
+        desc_b, desc_d = None, None
+        if self.s1d_bands is not None and self.s1d_bands.shape[0] > 0:
+            stream = self.s1d_bands[:, i, j, :]
+            valid = np.nonzero(np.any(stream != 0, axis=-1))[0]
+            if len(valid) > 0:
+                desc_b = stream[valid].astype(np.float32, copy=False)
+                desc_b = (desc_b - self.s1d_mean) / (self.s1d_std + 1e-9)
+                desc_d = np.asarray(self.s1d_doys)[valid].astype(np.float32, copy=False)
+
+        parts_b = [b for b in (asc_b, desc_b) if b is not None]
+        parts_d = [d for d in (asc_d, desc_d) if d is not None]
+        if not parts_b:
             return np.zeros((target, 3), dtype=np.float32)
-        stream = bands_arr[:, i, j, :]
-        valid = np.nonzero(np.any(stream != 0, axis=-1))[0]
-        if len(valid) == 0:
-            return np.zeros((target, 3), dtype=np.float32)
-        idx_local = build_resample_indices(len(valid), target)
-        real = valid[idx_local]
-        sub_b = stream[real].astype(np.float32, copy=False)
-        sub_d = np.asarray(doys_arr)[real]
-        sub_b = (sub_b - S1_BAND_MEAN) / (S1_BAND_STD + 1e-9)
+
+        all_b = np.concatenate(parts_b, axis=0)
+        all_d = np.concatenate(parts_d, axis=0)
+
+        idx_local = build_resample_indices(len(all_b), target)
+        sub_b = all_b[idx_local]
+        sub_d = all_d[idx_local]
         return np.hstack([sub_b, sub_d.reshape(-1, 1)]).astype(np.float32, copy=False)
 
     def __getitem__(self, idx):
         i, j = self.pixel_coords[idx]
         bin_key = self.pixel_bin_keys[idx]
-        s2_t, s1a_t, s1d_t = int(bin_key["s2"]), int(bin_key["s1a"]), int(bin_key["s1d"])
+        s2_t, s1_t = int(bin_key["s2"]), int(bin_key["s1"])
 
         s2 = self._sample_s2(i, j, s2_t) if self.use_s2 else np.zeros((0, 11), dtype=np.float32)
-        s1a = self._sample_s1_stream(self.s1a_bands, self.s1a_doys, i, j, s1a_t) if self.use_s1 else np.zeros((0, 3), dtype=np.float32)
-        s1d = self._sample_s1_stream(self.s1d_bands, self.s1d_doys, i, j, s1d_t) if self.use_s1 else np.zeros((0, 3), dtype=np.float32)
+        s1 = self._sample_s1_merged(i, j, s1_t) if self.use_s1 else np.zeros((0, 3), dtype=np.float32)
 
         return {
             "s2": torch.from_numpy(s2),
-            "s1a": torch.from_numpy(s1a),
-            "s1d": torch.from_numpy(s1d),
+            "s1": torch.from_numpy(s1),
             "i": int(i),
             "j": int(j),
             "global_idx": int(i) * self.W + int(j),
-            "bin_key": (s2_t, s1a_t, s1d_t),
+            "bin_key": (s2_t, s1_t),
         }

--- a/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
+++ b/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
@@ -14,6 +14,16 @@
 import numpy as np
 
 
+# NOTE (2026-04-26): the AWS row below was computed from preprocessing output
+# that double-applied the PB-04.00 BOA_ADD_OFFSET to AWS / Earth-search
+# Sentinel-2 data (the bug fixed in tessera_preprocessing/s2_fast_processor.py).
+# These AWS stats are therefore offset ~1000 lower for bands whose true value
+# exceeds the offset on post-2022-01-25 acquisitions. They are kept here ONLY
+# so the currently-published AWS v1.1 checkpoints continue to receive
+# in-distribution inputs — i.e. AWS inference is consistent ONLY when paired
+# with the OLD (buggy) preprocessing output. After the AWS checkpoint is
+# re-pretrained on corrected preprocessing output, recompute and replace this
+# row from the new training data and remove this notice.
 NORM_STATS = {
     "mpc": {
         "s2_mean": np.array([2683.4553, 2223.3630, 2432.0950, 3633.1970, 3602.1755,

--- a/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
+++ b/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
@@ -10,20 +10,17 @@
 # Note: although v1.1 uses a single merged S1 backbone (split_s1_modalities=False),
 # S1 ascending and S1 descending are normalised with their OWN mean/std before
 # being concatenated — this matches the v1.1 training-time preprocessing.
+#
+# AWS row was refreshed on 2026-05-03 against the AWS pretraining data collected
+# AFTER the BOA_ADD_OFFSET double-apply bug was fixed in
+# `tessera_preprocessing/s2_fast_processor.py::harmonize_arr` and AFTER the AWS
+# v1.1 checkpoint was retrained on that corrected output. The Landsat block under
+# MPC is unused by the current v1.1 inference graph (use_landsat=False) and is
+# kept for forward compatibility / fine-tuning recipes that turn Landsat on.
 
 import numpy as np
 
 
-# NOTE (2026-04-26): the AWS row below was computed from preprocessing output
-# that double-applied the PB-04.00 BOA_ADD_OFFSET to AWS / Earth-search
-# Sentinel-2 data (the bug fixed in tessera_preprocessing/s2_fast_processor.py).
-# These AWS stats are therefore offset ~1000 lower for bands whose true value
-# exceeds the offset on post-2022-01-25 acquisitions. They are kept here ONLY
-# so the currently-published AWS v1.1 checkpoints continue to receive
-# in-distribution inputs — i.e. AWS inference is consistent ONLY when paired
-# with the OLD (buggy) preprocessing output. After the AWS checkpoint is
-# re-pretrained on corrected preprocessing output, recompute and replace this
-# row from the new training data and remove this notice.
 NORM_STATS = {
     "mpc": {
         "s2_mean": np.array([2683.4553, 2223.3630, 2432.0950, 3633.1970, 3602.1755,
@@ -34,16 +31,21 @@ NORM_STATS = {
         "s1a_std":  np.array([1713.4646, 1693.0471], dtype=np.float32),
         "s1d_mean": np.array([5552.9683, 2955.0520], dtype=np.float32),
         "s1d_std":  np.array([1685.5857, 1677.6414], dtype=np.float32),
+        # Landsat first-6-bands; only consumed when use_landsat=True (v1.1 default off).
+        "landsat_mean": np.array([16229.6855, 16999.7637, 17590.2109,
+                                  21526.4531, 15207.2490, 13286.6963], dtype=np.float32),
+        "landsat_std":  np.array([14196.8818, 13033.0557, 13078.4229,
+                                  9735.7246,  5547.3047,  4899.0557], dtype=np.float32),
     },
     "aws": {
-        "s2_mean": np.array([2501.1238, 2113.7524, 2270.7112, 3315.6033, 3289.6584,
-                             2757.2700, 3092.8628, 3212.9587, 2170.0745, 1759.2500], dtype=np.float32),
-        "s2_std":  np.array([2739.4775, 2843.0742, 2685.2820, 2387.8638, 2194.2751,
-                             2733.0715, 2481.0159, 2332.5276, 1673.3186, 1549.3647], dtype=np.float32),
-        "s1a_mean": np.array([5664.5439, 2802.9736], dtype=np.float32),
-        "s1a_std":  np.array([1678.7821, 1786.0414], dtype=np.float32),
-        "s1d_mean": np.array([5710.6992, 2830.1045], dtype=np.float32),
-        "s1d_std":  np.array([1616.1969, 1761.8499], dtype=np.float32),
+        "s2_mean": np.array([2793.6589, 2356.7776, 2551.0496, 3741.9229, 3713.7844,
+                             3120.1997, 3516.3342, 3637.0342, 2501.0283, 2038.1504], dtype=np.float32),
+        "s2_std":  np.array([2810.0093, 2933.8835, 2755.6360, 2344.5027, 2145.7986,
+                             2743.9019, 2438.8601, 2286.5977, 1680.7367, 1585.5529], dtype=np.float32),
+        "s1a_mean": np.array([5697.0859, 2838.6687], dtype=np.float32),
+        "s1a_std":  np.array([1671.3737, 1789.4116], dtype=np.float32),
+        "s1d_mean": np.array([5759.1367, 2873.2854], dtype=np.float32),
+        "s1d_std":  np.array([1583.2858, 1747.8390], dtype=np.float32),
     },
 }
 

--- a/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
+++ b/tessera_infer_QAT/src/datasets/v1_1_norm_stats.py
@@ -1,0 +1,49 @@
+# src/datasets/v1_1_norm_stats.py
+#
+# Per-source normalisation statistics used by Tessera v1.1 inference.
+# v1.1 ships two checkpoints — one trained on Microsoft Planetary Computer (MPC)
+# preprocessing output and one fine-tuned on AWS (Earth-search S2 + ASF OPERA S1)
+# preprocessing output. Each checkpoint has its OWN per-band mean/std; mixing them
+# silently corrupts the input distribution and degrades embedding quality.
+#
+# `data_source` is selected from the inference config (`config["data_source"]`).
+# Note: although v1.1 uses a single merged S1 backbone (split_s1_modalities=False),
+# S1 ascending and S1 descending are normalised with their OWN mean/std before
+# being concatenated — this matches the v1.1 training-time preprocessing.
+
+import numpy as np
+
+
+NORM_STATS = {
+    "mpc": {
+        "s2_mean": np.array([2683.4553, 2223.3630, 2432.0950, 3633.1970, 3602.1755,
+                             3006.4324, 3400.2710, 3515.6392, 2456.9163, 1983.8783], dtype=np.float32),
+        "s2_std":  np.array([2739.5217, 2846.2993, 2690.8250, 2290.0439, 2088.8970,
+                             2673.1106, 2381.4521, 2229.5225, 1601.0942, 1495.3545], dtype=np.float32),
+        "s1a_mean": np.array([5588.3291, 3025.6270], dtype=np.float32),
+        "s1a_std":  np.array([1713.4646, 1693.0471], dtype=np.float32),
+        "s1d_mean": np.array([5552.9683, 2955.0520], dtype=np.float32),
+        "s1d_std":  np.array([1685.5857, 1677.6414], dtype=np.float32),
+    },
+    "aws": {
+        "s2_mean": np.array([2501.1238, 2113.7524, 2270.7112, 3315.6033, 3289.6584,
+                             2757.2700, 3092.8628, 3212.9587, 2170.0745, 1759.2500], dtype=np.float32),
+        "s2_std":  np.array([2739.4775, 2843.0742, 2685.2820, 2387.8638, 2194.2751,
+                             2733.0715, 2481.0159, 2332.5276, 1673.3186, 1549.3647], dtype=np.float32),
+        "s1a_mean": np.array([5664.5439, 2802.9736], dtype=np.float32),
+        "s1a_std":  np.array([1678.7821, 1786.0414], dtype=np.float32),
+        "s1d_mean": np.array([5710.6992, 2830.1045], dtype=np.float32),
+        "s1d_std":  np.array([1616.1969, 1761.8499], dtype=np.float32),
+    },
+}
+
+
+def get_stats(data_source: str):
+    key = str(data_source).lower()
+    if key not in NORM_STATS:
+        raise ValueError(
+            f"Unknown data_source={data_source!r}. Expected one of {sorted(NORM_STATS)}. "
+            "MPC and AWS checkpoints have DIFFERENT normalisation stats — pick the one "
+            "that matches your downloaded checkpoint."
+        )
+    return NORM_STATS[key]

--- a/tessera_infer_QAT/src/infer_v1_1.py
+++ b/tessera_infer_QAT/src/infer_v1_1.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Tessera v1.1 QAT inference entry point (single-tile, single-process, GPU or CPU).
+#
+# Data layout (same as v1.0 `tessera_infer` / `tessera_infer_QAT` pipeline): point
+# `--tile_path` at a directory produced by `tessera_preprocessing`, containing
+#     bands.npy, masks.npy, doys.npy,
+#     sar_ascending.npy,  sar_ascending_doy.npy,
+#     sar_descending.npy, sar_descending_doy.npy
+#
+# Usage (GPU):
+#     python src/infer_v1_1.py \
+#         --config          configs/v1_1_infer_config.py \
+#         --checkpoint_path checkpoints/best_model_fsdp_20260408_154724.pt \
+#         --tile_path       /path/to/retiled_d_pixel/0_3500_500_4000 \
+#         --output_dir      /path/to/representation_retiled_v1_1 \
+#         --output_prefix   0_3500_500_4000
+#
+# Output (in --output_dir):
+#     <prefix>_emb128_int8.npy   (H, W, 128) int8
+#     <prefix>_emb128_scales.npy (H, W)      float32 per-pixel scale
+#
+#     To reconstruct fp32: emb_int8.astype(float32) * scales[..., None]
+
+import argparse
+import importlib.util
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+from contextlib import nullcontext
+
+import numpy as np
+import torch
+from torch.utils.data import BatchSampler, DataLoader
+
+os.environ.setdefault("PYTORCH_SDP_DISABLE_FLASH_ATTENTION", "1")
+os.environ.setdefault("PYTORCH_SDP_DISABLE_MEM_EFFICIENT_ATTENTION", "1")
+
+# Make `src/` imports work regardless of how the script is launched.
+SRC_DIR = os.path.dirname(os.path.abspath(__file__))
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+from datasets.ssl_dataset_v1_1 import SingleTileInferenceDatasetV1_1
+from models.quantization import quantize_tensor_symmetric_per_row  # added below
+from models.ssl_model_v1_1 import build_v1_1_inference_model, load_v1_1_checkpoint
+
+
+# ---------------------------------------------------------------------------
+# Bucketised batch sampler: each batch contains pixels sharing the same bin_key
+# so Transformer inputs within a batch have identical sequence length.
+# ---------------------------------------------------------------------------
+
+class BucketBatchSampler(BatchSampler):
+    def __init__(self, dataset: SingleTileInferenceDatasetV1_1, batch_size: int):
+        self.dataset = dataset
+        self.batch_size = int(batch_size)
+        self._batches = []
+        for key in sorted(dataset.bins_to_indices.keys()):
+            idxs = dataset.bins_to_indices[key]
+            for start in range(0, len(idxs), self.batch_size):
+                chunk = idxs[start:start + self.batch_size]
+                if chunk:
+                    self._batches.append(chunk)
+
+    def __iter__(self):
+        for b in self._batches:
+            yield b
+
+    def __len__(self):
+        return len(self._batches)
+
+
+def _collate(batch_list):
+    """Pixels in one batch share a bin_key → all tensors already have identical
+    seq length; we just stack."""
+    return {
+        "s2": torch.stack([b["s2"] for b in batch_list], dim=0),
+        "s1a": torch.stack([b["s1a"] for b in batch_list], dim=0),
+        "s1d": torch.stack([b["s1d"] for b in batch_list], dim=0),
+        "i": torch.tensor([b["i"] for b in batch_list], dtype=torch.long),
+        "j": torch.tensor([b["j"] for b in batch_list], dtype=torch.long),
+        "global_idx": torch.tensor([b["global_idx"] for b in batch_list], dtype=torch.long),
+    }
+
+
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Tessera v1.1 QAT single-tile inference")
+    p.add_argument("--config", required=True, help="Path to Python config file (exports `config = {...}`)")
+    p.add_argument("--checkpoint_path", required=True)
+    p.add_argument("--tile_path", required=True,
+                   help="Directory with bands.npy, masks.npy, doys.npy, sar_ascending{,_doy}.npy, sar_descending{,_doy}.npy")
+    p.add_argument("--output_dir", required=True, help="Directory to write <prefix>_emb128_int8.npy / _scales.npy")
+    p.add_argument("--output_prefix", default=None,
+                   help="Output file prefix. Defaults to basename of --tile_path (matches v1.0 pipeline).")
+    p.add_argument("--device", default=None, choices=["cuda", "cpu", "xpu"])
+    p.add_argument("--batch_size", type=int, default=None)
+    p.add_argument("--num_workers", type=int, default=None)
+    return p.parse_args()
+
+
+def load_config(path):
+    spec = importlib.util.spec_from_file_location("v1_1_config_module", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.config
+
+
+def pick_device(arg_device):
+    if arg_device == "cpu":
+        return torch.device("cpu")
+    if arg_device == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested but not available.")
+        return torch.device("cuda")
+    if arg_device == "xpu":
+        import intel_extension_for_pytorch  # noqa: F401
+        if not torch.xpu.is_available():
+            raise RuntimeError("XPU requested but not available.")
+        return torch.device("xpu")
+    # Auto
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def main():
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    config = load_config(args.config)
+    if args.batch_size is not None:
+        config["batch_size"] = args.batch_size
+    if args.num_workers is not None:
+        config["num_workers"] = args.num_workers
+
+    tile_path = os.path.abspath(args.tile_path.rstrip("/"))
+    output_dir = os.path.abspath(args.output_dir)
+    output_prefix = args.output_prefix or os.path.basename(tile_path)
+
+    device = pick_device(args.device)
+    logging.info("Device: %s", device)
+    logging.info("Checkpoint: %s", args.checkpoint_path)
+    logging.info("Tile: %s", tile_path)
+    logging.info("Output: %s  (prefix=%s)", output_dir, output_prefix)
+    logging.info("num_obs_checkpoints: %s", config["num_obs_checkpoints"])
+
+    # Build and load model
+    model = build_v1_1_inference_model(config, device)
+    missing, unexpected, ckpt_cfg = load_v1_1_checkpoint(model, args.checkpoint_path)
+    logging.info("Loaded checkpoint. missing=%d unexpected=%d", len(missing), len(unexpected))
+    if missing:
+        logging.info("Missing (first 10): %s", missing[:10])
+    if unexpected:
+        logging.info("Unexpected (first 10): %s", unexpected[:10])
+    model.eval()
+    for p in model.parameters():
+        p.requires_grad = False
+
+    # Build dataset + bucketised loader
+    dataset = SingleTileInferenceDatasetV1_1(tile_path=tile_path, config=config)
+    sampler = BucketBatchSampler(dataset, batch_size=int(config.get("batch_size", 1024)))
+    loader = DataLoader(
+        dataset,
+        batch_sampler=sampler,
+        num_workers=int(config.get("num_workers", 8)),
+        pin_memory=(device.type == "cuda"),
+        persistent_workers=bool(int(config.get("num_workers", 8)) > 0),
+        collate_fn=_collate,
+    )
+
+    # Output buffers (allocated on host)
+    H, W = dataset.H, dataset.W
+    save_dim = int(min(int(config.get("save_embedding_dim", 128)), int(config.get("representation_dim", 192))))
+    emb_int8 = np.zeros((H, W, save_dim), dtype=np.int8)
+    scales = np.zeros((H, W), dtype=np.float32)
+
+    amp_ctx = nullcontext()
+    if bool(config.get("apply_amp", True)) and device.type == "cuda":
+        amp_dtype = torch.bfloat16 if bool(config.get("use_bf16", True)) else torch.float16
+        amp_ctx = torch.amp.autocast("cuda", dtype=amp_dtype)
+
+    total = len(loader)
+    log_every = int(config.get("log_interval_steps", 20))
+    start = time.time()
+    written = 0
+
+    with torch.no_grad():
+        for step, batch in enumerate(loader, start=1):
+            s2 = batch["s2"].to(device, non_blocking=True)
+            s1a = batch["s1a"].to(device, non_blocking=True)
+            s1d = batch["s1d"].to(device, non_blocking=True)
+
+            with amp_ctx:
+                emb = model(s2, s1a, s1d)  # (B, repr_dim)
+
+            emb = emb[:, :save_dim].to(torch.float32)
+            q_int8, per_row_scale = quantize_tensor_symmetric_per_row(emb, bits=int(config.get("qat_representation_bits", 8)))
+
+            q_np = q_int8.cpu().numpy()
+            s_np = per_row_scale.cpu().numpy().astype(np.float32).reshape(-1)
+            ii = batch["i"].numpy()
+            jj = batch["j"].numpy()
+            emb_int8[ii, jj, :] = q_np
+            scales[ii, jj] = s_np
+            written += q_np.shape[0]
+
+            if step % log_every == 0 or step == total:
+                elapsed = time.time() - start
+                rate = written / elapsed if elapsed > 0 else 0.0
+                logging.info("Progress %d/%d batches, %d pixels, %.1f px/s", step, total, written, rate)
+
+    os.makedirs(output_dir, exist_ok=True)
+    out_int8 = os.path.join(output_dir, f"{output_prefix}_emb{save_dim}_int8.npy")
+    out_scl = os.path.join(output_dir, f"{output_prefix}_emb{save_dim}_scales.npy")
+    np.save(out_int8, emb_int8)
+    np.save(out_scl, scales)
+    logging.info("Saved: %s  (shape=%s, dtype=%s)", out_int8, emb_int8.shape, emb_int8.dtype)
+    logging.info("Saved: %s  (shape=%s, dtype=%s)", out_scl, scales.shape, scales.dtype)
+    logging.info("Done. total_pixels=%d elapsed=%.1fs", written, time.time() - start)
+
+
+if __name__ == "__main__":
+    main()

--- a/tessera_infer_QAT/src/infer_v1_1.py
+++ b/tessera_infer_QAT/src/infer_v1_1.py
@@ -79,8 +79,7 @@ def _collate(batch_list):
     seq length; we just stack."""
     return {
         "s2": torch.stack([b["s2"] for b in batch_list], dim=0),
-        "s1a": torch.stack([b["s1a"] for b in batch_list], dim=0),
-        "s1d": torch.stack([b["s1d"] for b in batch_list], dim=0),
+        "s1": torch.stack([b["s1"] for b in batch_list], dim=0),
         "i": torch.tensor([b["i"] for b in batch_list], dtype=torch.long),
         "j": torch.tensor([b["j"] for b in batch_list], dtype=torch.long),
         "global_idx": torch.tensor([b["global_idx"] for b in batch_list], dtype=torch.long),
@@ -101,6 +100,8 @@ def parse_args():
     p.add_argument("--device", default=None, choices=["cuda", "cpu", "xpu"])
     p.add_argument("--batch_size", type=int, default=None)
     p.add_argument("--num_workers", type=int, default=None)
+    p.add_argument("--data_source", default=None, choices=["mpc", "aws"],
+                   help="Override config['data_source']. MUST match the loaded checkpoint.")
     return p.parse_args()
 
 
@@ -138,6 +139,8 @@ def main():
         config["batch_size"] = args.batch_size
     if args.num_workers is not None:
         config["num_workers"] = args.num_workers
+    if args.data_source is not None:
+        config["data_source"] = args.data_source
 
     tile_path = os.path.abspath(args.tile_path.rstrip("/"))
     output_dir = os.path.abspath(args.output_dir)
@@ -148,6 +151,7 @@ def main():
     logging.info("Checkpoint: %s", args.checkpoint_path)
     logging.info("Tile: %s", tile_path)
     logging.info("Output: %s  (prefix=%s)", output_dir, output_prefix)
+    logging.info("data_source: %s", config.get("data_source", "mpc"))
     logging.info("num_obs_checkpoints: %s", config["num_obs_checkpoints"])
 
     # Build and load model
@@ -193,11 +197,10 @@ def main():
     with torch.no_grad():
         for step, batch in enumerate(loader, start=1):
             s2 = batch["s2"].to(device, non_blocking=True)
-            s1a = batch["s1a"].to(device, non_blocking=True)
-            s1d = batch["s1d"].to(device, non_blocking=True)
+            s1 = batch["s1"].to(device, non_blocking=True)
 
             with amp_ctx:
-                emb = model(s2, s1a, s1d)  # (B, repr_dim)
+                emb = model(s2, s1)  # (B, repr_dim)
 
             emb = emb[:, :save_dim].to(torch.float32)
             q_int8, per_row_scale = quantize_tensor_symmetric_per_row(emb, bits=int(config.get("qat_representation_bits", 8)))

--- a/tessera_infer_QAT/src/models/quantization.py
+++ b/tessera_infer_QAT/src/models/quantization.py
@@ -89,3 +89,29 @@ def dequantize_tensor_symmetric(x_quantized, scale):
     Dequantizes an integer tensor back to f32 using the scale factor.
     """
     return x_quantized.float() * scale
+
+
+def quantize_tensor_symmetric_per_row(x_f32, bits=8):
+    """
+    Per-row symmetric quantisation. Input shape ``(..., D)``; scale is computed
+    independently along the last axis so a (B, D) batch yields (B, 1) scales.
+    This matches the deployed Tessera v1.1 int8 embedding format, where every
+    pixel carries its own scale.
+    """
+    if bits == 8:
+        qmin, qmax, dtype = -128, 127, torch.int8
+    else:
+        qmin = -2 ** (bits - 1)
+        qmax = 2 ** (bits - 1) - 1
+        if bits <= 8:
+            dtype = torch.int8
+        elif bits <= 16:
+            dtype = torch.int16
+        else:
+            dtype = torch.int32
+    x_f32 = x_f32.to(torch.float32)
+    abs_max = torch.amax(torch.abs(x_f32.detach()), dim=-1, keepdim=True)
+    scale = torch.clamp(abs_max / qmax, min=1e-8)
+    q = torch.round(x_f32 / scale)
+    q = torch.clamp(q, qmin, qmax).to(dtype)
+    return q, scale

--- a/tessera_infer_QAT/src/models/ssl_model_v1_1.py
+++ b/tessera_infer_QAT/src/models/ssl_model_v1_1.py
@@ -1,0 +1,133 @@
+# src/models/ssl_model_v1_1.py
+#
+# Inference-only assembly of the Tessera v1.1 representation model.
+# Three backbones (S2, S1-ascending, S1-descending) -> concat fusion -> MLP dim_reducer.
+# The projector is intentionally NOT included — v1.1 pretraining's projector is
+# discarded at inference time, matching v2 training's inference path.
+
+import torch
+import torch.nn as nn
+
+from .modules import TransformerEncoder
+
+
+class MultimodalV1_1InferenceModel(nn.Module):
+    """Assembles the three v1.1 backbones and the MLP dim_reducer.
+
+    The dim_reducer matches v2 training exactly:
+        Linear(in, in*2) -> LayerNorm(in*2) -> ReLU -> Dropout(0.2) -> Linear(in*2, repr_dim)
+    where in = latent_dim * 4 * num_active_backbones (concat fusion).
+    """
+
+    def __init__(self, s2_backbone, s1a_backbone, s1d_backbone, dim_reducer, fusion_method="concat"):
+        super().__init__()
+        self.s2_backbone = s2_backbone
+        self.s1a_backbone = s1a_backbone
+        self.s1d_backbone = s1d_backbone
+        self.dim_reducer = dim_reducer
+        self.fusion_method = fusion_method
+
+    def forward(self, s2_x, s1a_x, s1d_x):
+        reprs = []
+        if self.s2_backbone is not None:
+            reprs.append(self.s2_backbone(s2_x))
+        if self.s1a_backbone is not None:
+            reprs.append(self.s1a_backbone(s1a_x))
+        if self.s1d_backbone is not None:
+            reprs.append(self.s1d_backbone(s1d_x))
+
+        if self.fusion_method == "concat":
+            fused = torch.cat(reprs, dim=-1)
+        elif self.fusion_method == "sum":
+            fused = sum(reprs)
+        else:
+            raise ValueError(f"Unknown fusion_method: {self.fusion_method}")
+
+        return self.dim_reducer(fused)
+
+
+def build_v1_1_inference_model(config, device):
+    """Construct the v1.1 inference model from config.
+
+    Input config must specify at minimum: latent_dim, representation_dim,
+    s2/s1 heads/layers/dim_feedforward, split_s1_modalities=True, fusion_method,
+    num_obs_checkpoints (max determines max_seq_len in the encoders).
+    """
+    latent_dim = int(config.get("latent_dim", 192))
+    repr_dim = int(config.get("representation_dim", latent_dim))
+    fusion_method = config.get("fusion_method", "concat")
+    split_s1 = bool(config.get("split_s1_modalities", True))
+    if not split_s1:
+        raise NotImplementedError("Tessera v1.1 expects split_s1_modalities=True.")
+
+    max_seq_len = max(int(v) for v in config.get("num_obs_checkpoints", [128]) if int(v) > 0)
+
+    s2_enc = TransformerEncoder(
+        band_num=10,
+        latent_dim=latent_dim,
+        nhead=int(config["s2_num_heads"]),
+        num_encoder_layers=int(config["s2_num_layers"]),
+        dim_feedforward=int(config["s2_dim_feedforward"]),
+        dropout=0.1,
+        max_seq_len=max_seq_len,
+    ).to(device)
+
+    s1a_enc = TransformerEncoder(
+        band_num=2,
+        latent_dim=latent_dim,
+        nhead=int(config["s1_num_heads"]),
+        num_encoder_layers=int(config["s1_num_layers"]),
+        dim_feedforward=int(config["s1_dim_feedforward"]),
+        dropout=0.1,
+        max_seq_len=max_seq_len,
+    ).to(device)
+
+    s1d_enc = TransformerEncoder(
+        band_num=2,
+        latent_dim=latent_dim,
+        nhead=int(config["s1_num_heads"]),
+        num_encoder_layers=int(config["s1_num_layers"]),
+        dim_feedforward=int(config["s1_dim_feedforward"]),
+        dropout=0.1,
+        max_seq_len=max_seq_len,
+    ).to(device)
+
+    active = 3 if fusion_method == "concat" else 1
+    reducer_in = latent_dim * 4 * active
+    dim_reducer = nn.Sequential(
+        nn.Linear(reducer_in, reducer_in * 2),
+        nn.LayerNorm(reducer_in * 2),
+        nn.ReLU(inplace=False),
+        nn.Dropout(0.2),
+        nn.Linear(reducer_in * 2, repr_dim),
+    ).to(device)
+
+    return MultimodalV1_1InferenceModel(
+        s2_backbone=s2_enc,
+        s1a_backbone=s1a_enc,
+        s1d_backbone=s1d_enc,
+        dim_reducer=dim_reducer,
+        fusion_method=fusion_method,
+    )
+
+
+def load_v1_1_checkpoint(model: MultimodalV1_1InferenceModel, checkpoint_path: str):
+    """Load an FSDP v1.1 checkpoint into the inference model.
+
+    Strips the `_orig_mod.` prefix added by torch.compile-wrapped FSDP and skips
+    projector weights (which are not part of the inference graph).
+    """
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    state_key = "model_state" if "model_state" in ckpt else "model_state_dict"
+    raw = ckpt[state_key]
+
+    cleaned = {}
+    for k, v in raw.items():
+        if k.startswith("_orig_mod."):
+            k = k[len("_orig_mod."):]
+        if k.startswith("projector.") or k.startswith("segmented_matryoshka_projector."):
+            continue
+        cleaned[k] = v
+
+    missing, unexpected = model.load_state_dict(cleaned, strict=False)
+    return missing, unexpected, ckpt.get("config", {})

--- a/tessera_infer_QAT/src/models/ssl_model_v1_1.py
+++ b/tessera_infer_QAT/src/models/ssl_model_v1_1.py
@@ -1,9 +1,14 @@
 # src/models/ssl_model_v1_1.py
 #
-# Inference-only assembly of the Tessera v1.1 representation model.
-# Three backbones (S2, S1-ascending, S1-descending) -> concat fusion -> MLP dim_reducer.
-# The projector is intentionally NOT included — v1.1 pretraining's projector is
-# discarded at inference time, matching v2 training's inference path.
+# Inference-only assembly of the Tessera v1.1 representation model (this revision:
+# split_s1_modalities=False, matching v1.0's two-backbone topology).
+#
+#   S2 backbone   ┐
+#                 ├─ concat (latent_dim*4 * 2) → MLP dim_reducer → 192-D embedding
+#   S1 backbone   ┘   (S1 backbone consumes the concatenated S1-asc + S1-desc stream,
+#                      each per-modality-normalised by the dataset before merging.)
+#
+# The projector used during pretraining is intentionally NOT included.
 
 import torch
 import torch.nn as nn
@@ -12,29 +17,26 @@ from .modules import TransformerEncoder
 
 
 class MultimodalV1_1InferenceModel(nn.Module):
-    """Assembles the three v1.1 backbones and the MLP dim_reducer.
+    """Two backbones (S2 + merged S1) with an MLP `dim_reducer`.
 
-    The dim_reducer matches v2 training exactly:
+    The dim_reducer matches v1.1 training exactly:
         Linear(in, in*2) -> LayerNorm(in*2) -> ReLU -> Dropout(0.2) -> Linear(in*2, repr_dim)
     where in = latent_dim * 4 * num_active_backbones (concat fusion).
     """
 
-    def __init__(self, s2_backbone, s1a_backbone, s1d_backbone, dim_reducer, fusion_method="concat"):
+    def __init__(self, s2_backbone, s1_backbone, dim_reducer, fusion_method="concat"):
         super().__init__()
         self.s2_backbone = s2_backbone
-        self.s1a_backbone = s1a_backbone
-        self.s1d_backbone = s1d_backbone
+        self.s1_backbone = s1_backbone
         self.dim_reducer = dim_reducer
         self.fusion_method = fusion_method
 
-    def forward(self, s2_x, s1a_x, s1d_x):
+    def forward(self, s2_x, s1_x):
         reprs = []
         if self.s2_backbone is not None:
             reprs.append(self.s2_backbone(s2_x))
-        if self.s1a_backbone is not None:
-            reprs.append(self.s1a_backbone(s1a_x))
-        if self.s1d_backbone is not None:
-            reprs.append(self.s1d_backbone(s1d_x))
+        if self.s1_backbone is not None:
+            reprs.append(self.s1_backbone(s1_x))
 
         if self.fusion_method == "concat":
             fused = torch.cat(reprs, dim=-1)
@@ -49,16 +51,19 @@ class MultimodalV1_1InferenceModel(nn.Module):
 def build_v1_1_inference_model(config, device):
     """Construct the v1.1 inference model from config.
 
-    Input config must specify at minimum: latent_dim, representation_dim,
-    s2/s1 heads/layers/dim_feedforward, split_s1_modalities=True, fusion_method,
-    num_obs_checkpoints (max determines max_seq_len in the encoders).
+    Required config keys: latent_dim, representation_dim, fusion_method,
+    s2_num_heads/num_layers/dim_feedforward, s1_num_heads/num_layers/dim_feedforward,
+    num_obs_checkpoints (max determines max_seq_len passed to the encoders).
     """
+    if bool(config.get("split_s1_modalities", False)):
+        raise NotImplementedError(
+            "v1.1 (this revision) requires split_s1_modalities=False — S1-asc and "
+            "S1-desc are concatenated before the single merged S1 backbone."
+        )
+
     latent_dim = int(config.get("latent_dim", 192))
     repr_dim = int(config.get("representation_dim", latent_dim))
     fusion_method = config.get("fusion_method", "concat")
-    split_s1 = bool(config.get("split_s1_modalities", True))
-    if not split_s1:
-        raise NotImplementedError("Tessera v1.1 expects split_s1_modalities=True.")
 
     max_seq_len = max(int(v) for v in config.get("num_obs_checkpoints", [128]) if int(v) > 0)
 
@@ -72,7 +77,7 @@ def build_v1_1_inference_model(config, device):
         max_seq_len=max_seq_len,
     ).to(device)
 
-    s1a_enc = TransformerEncoder(
+    s1_enc = TransformerEncoder(
         band_num=2,
         latent_dim=latent_dim,
         nhead=int(config["s1_num_heads"]),
@@ -82,17 +87,7 @@ def build_v1_1_inference_model(config, device):
         max_seq_len=max_seq_len,
     ).to(device)
 
-    s1d_enc = TransformerEncoder(
-        band_num=2,
-        latent_dim=latent_dim,
-        nhead=int(config["s1_num_heads"]),
-        num_encoder_layers=int(config["s1_num_layers"]),
-        dim_feedforward=int(config["s1_dim_feedforward"]),
-        dropout=0.1,
-        max_seq_len=max_seq_len,
-    ).to(device)
-
-    active = 3 if fusion_method == "concat" else 1
+    active = 2 if fusion_method == "concat" else 1
     reducer_in = latent_dim * 4 * active
     dim_reducer = nn.Sequential(
         nn.Linear(reducer_in, reducer_in * 2),
@@ -104,8 +99,7 @@ def build_v1_1_inference_model(config, device):
 
     return MultimodalV1_1InferenceModel(
         s2_backbone=s2_enc,
-        s1a_backbone=s1a_enc,
-        s1d_backbone=s1d_enc,
+        s1_backbone=s1_enc,
         dim_reducer=dim_reducer,
         fusion_method=fusion_method,
     )
@@ -115,7 +109,8 @@ def load_v1_1_checkpoint(model: MultimodalV1_1InferenceModel, checkpoint_path: s
     """Load an FSDP v1.1 checkpoint into the inference model.
 
     Strips the `_orig_mod.` prefix added by torch.compile-wrapped FSDP and skips
-    projector weights (which are not part of the inference graph).
+    the projector / segmented-matryoshka-projector, which are not part of the
+    inference graph.
     """
     ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     state_key = "model_state" if "model_state" in ckpt else "model_state_dict"

--- a/tessera_infer_QAT/visualize_embedding_v1_1.py
+++ b/tessera_infer_QAT/visualize_embedding_v1_1.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Visualise Tessera v1.1 QAT embeddings.
+
+Loads the int8 embedding + per-pixel scales saved by src/infer_v1_1.py, dequantises
+to fp32, and saves:
+  - <prefix>_first3_rgb.png — first 3 embedding dimensions as an RGB image
+                              (each channel min/max normalised independently)
+  - <prefix>_pca3_rgb.png   — PCA to 3 components (for comparison)
+
+Usage:
+    python visualize_embedding_v1_1.py \
+        --emb_int8  path/to/<prefix>_emb128_int8.npy \
+        --emb_scales path/to/<prefix>_emb128_scales.npy \
+        --out_dir   path/to/out_dir \
+        --prefix    v1_1_austrian_crop
+"""
+
+import argparse
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def dequantize(emb_int8_path, scales_path):
+    emb = np.load(emb_int8_path)          # (H, W, C) int8
+    scales = np.load(scales_path)         # (H, W) float32
+    if emb.ndim != 3:
+        raise ValueError(f"Expected emb shape (H,W,C), got {emb.shape}")
+    if scales.ndim == 3 and scales.shape[-1] == 1:
+        scales = scales[..., 0]
+    f32 = emb.astype(np.float32) * scales[..., None]
+    return f32
+
+
+def minmax_norm(img):
+    out = img.astype(np.float32)
+    for c in range(out.shape[-1]):
+        lo = np.min(out[:, :, c])
+        hi = np.max(out[:, :, c])
+        if hi > lo:
+            out[:, :, c] = (out[:, :, c] - lo) / (hi - lo)
+        else:
+            out[:, :, c] = 0.0
+    return np.clip(out, 0.0, 1.0)
+
+
+def save_rgb(img, path, title):
+    fig = plt.figure(figsize=(10, 8))
+    plt.imshow(img)
+    plt.title(title)
+    plt.axis("off")
+    fig.savefig(path, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--emb_int8", required=True)
+    ap.add_argument("--emb_scales", required=True)
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--prefix", default="v1_1")
+    ap.add_argument("--skip_pca", action="store_true")
+    args = ap.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    data = dequantize(args.emb_int8, args.emb_scales)
+    print(f"Dequantised shape: {data.shape}, dtype={data.dtype}")
+
+    # First 3 dims as RGB
+    first3 = minmax_norm(data[:, :, :3].copy())
+    first3_path = os.path.join(args.out_dir, f"{args.prefix}_first3_rgb.png")
+    save_rgb(first3, first3_path, "v1.1 embedding — first 3 dims (min-max per channel)")
+    print("Saved:", first3_path)
+
+    if args.skip_pca:
+        return
+    try:
+        from sklearn.decomposition import PCA
+    except ImportError:
+        print("sklearn not available; skipping PCA.")
+        return
+
+    flat = data.reshape(-1, data.shape[-1])
+    pca = PCA(n_components=3)
+    proj = pca.fit_transform(flat)
+    pca_img = proj.reshape(data.shape[0], data.shape[1], 3)
+    pca_img = minmax_norm(pca_img)
+    pca_path = os.path.join(args.out_dir, f"{args.prefix}_pca3_rgb.png")
+    save_rgb(pca_img, pca_path, f"v1.1 embedding — PCA3 (explained={pca.explained_variance_ratio_.round(3)})")
+    print("Saved:", pca_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tessera_preprocessing/s2_fast_processor.py
+++ b/tessera_preprocessing/s2_fast_processor.py
@@ -743,6 +743,12 @@ def process_band(items, band_name, date_key, tpl, bbox_proj, mask_np, tile_selec
                 # Use stackstac.stack to load single band
                 assets = [band_name]
                 
+                # Bilinear for spectral bands so the native-20m bands (B05/B06/
+                # B07/B8A/B11/B12) are smoothly upsampled to the 10m output grid
+                # instead of being block-replicated. SCL takes a separate code
+                # path (`process_scl_assessment_and_generation`) which keeps
+                # Resampling.nearest because SCL values are categorical class
+                # IDs and must never be averaged.
                 da = stackstac.stack(
                     items=items,
                     assets=assets,
@@ -751,7 +757,7 @@ def process_band(items, band_name, date_key, tpl, bbox_proj, mask_np, tile_selec
                     bounds=bbox_proj,
                     chunksize=chunksize,
                     rescale=False,
-                    resampling=Resampling.nearest
+                    resampling=Resampling.bilinear
                 )
                 
                 # Flatten useless dimensions but keep multi-item dimension

--- a/tessera_preprocessing/s2_fast_processor.py
+++ b/tessera_preprocessing/s2_fast_processor.py
@@ -63,6 +63,7 @@ AWS_BAND_MAPPING = {
 # Will be set in main() based on --data_source
 BAND_MAPPING = MPC_BAND_MAPPING
 S2_BANDS = list(BAND_MAPPING.keys())
+DATA_SOURCE = "mpc"            # set in main(); controls baseline-offset handling
 BASELINE_CUTOFF = datetime.datetime(2022, 1, 25)
 BASELINE_OFFSET = 1000
 
@@ -391,8 +392,23 @@ def group_by_date(items, partition_id: str):
     return dict(sorted(g.items()))
 
 # ─── baseline correction ─────────────────────────────────────────────────────────────
-def harmonize_arr(arr: np.ndarray, date_key:str):
-    """Perform Baseline correction"""
+def harmonize_arr(arr: np.ndarray, date_key: str):
+    """Subtract the PB-04.00 BOA_ADD_OFFSET (1000) introduced on 2022-01-25.
+
+    Source-specific behaviour:
+      - MPC (planetarycomputer sentinel-2-l2a): COGs are stored RAW, i.e. with
+        the +1000 offset still present for post-cutoff acquisitions. We must
+        subtract 1000 here to harmonise with pre-04.00 scenes.
+      - AWS (Element84 earth-search sentinel-2-l2a): the offset has already
+        been removed at COG-generation time (per Element84 earth-search README:
+        "As part of the conversion to COGs, the offset has been applied"). The
+        data is therefore already harmonised; subtracting again would shift
+        post-2022-01-25 acquisitions ~1000 too low for bands whose value
+        exceeds the offset (matches the empirical ~1000 MPC↔AWS gap reported
+        by users).
+    """
+    if DATA_SOURCE == "aws":
+        return arr
     if datetime.datetime.strptime(date_key, "%Y-%m-%d") > BASELINE_CUTOFF:
         # Handle NaN values to avoid warnings
         valid_mask = ~np.isnan(arr) & (arr >= BASELINE_OFFSET)
@@ -1205,8 +1221,11 @@ def main():
     global TEMP_DIR
     TEMP_DIR = a.temp_dir
 
-    # Configure backend-dependent band mapping + STAC backend selection
-    global BAND_MAPPING, S2_BANDS
+    # Configure backend-dependent band mapping + STAC backend selection.
+    # DATA_SOURCE also gates the baseline-offset correction in `harmonize_arr`:
+    # MPC stores the raw +1000 offset, AWS earth-search has already removed it.
+    global BAND_MAPPING, S2_BANDS, DATA_SOURCE
+    DATA_SOURCE = a.data_source
     if a.data_source == "aws":
         BAND_MAPPING = AWS_BAND_MAPPING
         S2_BANDS = list(BAND_MAPPING.keys())

--- a/tessera_preprocessing/s2_fast_processor_test.py
+++ b/tessera_preprocessing/s2_fast_processor_test.py
@@ -718,6 +718,11 @@ def process_band(items, band_name, date_key, tpl, bbox_proj, mask_np, tile_selec
         # Use stackstac.stack to load single band
         assets = [band_name]
         
+        # Bilinear for spectral bands so the native-20m bands (B05/B06/B07/B8A/
+        # B11/B12) are smoothly upsampled to the 10m output grid instead of being
+        # block-replicated. SCL takes a separate code path
+        # (`process_scl_assessment_and_generation`) which keeps Resampling.nearest
+        # because SCL values are categorical class IDs and must never be averaged.
         da = stackstac.stack(
             items=items,
             assets=assets,
@@ -726,7 +731,7 @@ def process_band(items, band_name, date_key, tpl, bbox_proj, mask_np, tile_selec
             bounds=bbox_proj,
             chunksize=chunksize,
             rescale=False,
-            resampling=Resampling.nearest
+            resampling=Resampling.bilinear
         )
         
         # Flatten useless dimensions but keep multi-item dimension


### PR DESCRIPTION
This pull request introduces support for Tessera v1.1 QAT inference, which brings improved model architecture, new inference logic, and updated normalisation statistics. The changes add a new configuration for v1.1, implement a dataset loader that supports bucketised all-observation resampling, and provide source-specific normalisation stats for correct model operation. Documentation is updated to guide users through the new workflow and checkpoint selection.

**v1.1 Model and Inference Support:**

* Added a new inference config file (`v1_1_infer_config.py`) specifying v1.1 model parameters, observation bucketing, and the requirement to match the `data_source` to the correct checkpoint.
* Implemented `ssl_dataset_v1_1.py` for v1.1 inference, supporting bucketised all-observation resampling and per-modality S1 normalisation, with batching based on observation counts per pixel.

**Normalisation and Checkpoints:**

* Added `v1_1_norm_stats.py` with per-source (MPC/AWS) normalisation statistics, ensuring correct input scaling for each checkpoint and preventing silent embedding degradation.

**Documentation Updates:**

* Updated `README.md` with a comprehensive guide for v1.1, including model improvements, checkpoint options, data source selection, inference instructions, and output format details.