### PR TITLE
Make v2 preprocessing scripts location-independent and add a runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,19 +197,25 @@ DATA_DIR=/absolute/path/to/your/data_dir              # all outputs are written 
 PYTHON_ENV=/absolute/path/to/your/python_env/bin/python  # absolute path to your interpreter; only the Step 1 downloader needs it
 BASENAME=myregion_2024                                # final result file name (.npy and .tif)
 YEAR=2024                                             # data year, range [2017-2025]
-ROI_TIFF="${DATA_DIR}/0.roi/roi_convex_hull.tiff"     # ROI extent: downloaded over + used as geo-reference
+ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
 ```
 
-### Step 0 — Shapefile → ROI GeoTIFF *(skip if you already have a GeoTIFF)* → `0.roi/`
+### Step 0 — Prepare ROI GeoTIFF  → `0.roi/`
 
 ```bash
 mkdir -p "${DATA_DIR}/0.roi"
+# Copy your roi.tiff to ${DATA_DIR}/0.roi manually
+# cp /path/to/your/roi.shp "${DATA_DIR}/0.roi"
+
+# Or generate it from shapefile using script
+# Move your roi.shp to `0.roi` directory
+# mv /path/to/your/roi.shp "${DATA_DIR}/0.roi"
 python tessera_preprocessing/convert_shp_to_tiff.py \
     --shp_path   "${DATA_DIR}/0.roi/roi.shp" \
     --pixel_size 10
 ```
 
-Writes `roi.tiff` and `roi_convex_hull.tiff` beside the shapefile. `ROI_TIFF` above points at the convex-hull file — that is the extent the next step downloads over.
+`tessera_preprocessing/convert_shp_to_tiff.py` writes `roi.tiff` and `roi_convex_hull.tiff` beside the shapefile. `ROI_TIFF` above points at the Geotiff file — that is the extent the next step downloads over.
 
 - `--shp_path` — your input shapefile.
 - `--pixel_size` — metres per pixel (optional, default `10`).
@@ -328,6 +334,11 @@ Prefer two pastes over six? After running the variables block above (same shell 
 
 ```bash
 mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
+```
+
+Now place your shapefile in `"${DATA_DIR}/0.roi"` as `roi.shp`
+
+```bash
 python tessera_preprocessing/convert_shp_to_tiff.py \
     --shp_path "${DATA_DIR}/0.roi/roi.shp" --pixel_size 10
 INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This fetches the recommended **Medium** student into `tessera_infer_v2/student/c
 
 ```bash
 DATA_DIR=/absolute/path/to/your/data_dir              # all outputs are written under here
-PYTHON_ENV=/absolute/path/to/your/python_env/bin/python
+PYTHON_ENV=/absolute/path/to/your/python_env/bin/python  # absolute path to your interpreter; only the Step 1 downloader needs it
 BASENAME=myregion_2024                                # final result file name (.npy and .tif)
 YEAR=2024                                             # data year, range [2017-2025]
 ROI_TIFF="${DATA_DIR}/0.roi/roi_convex_hull.tiff"     # ROI extent: downloaded over + used as geo-reference
@@ -204,7 +204,7 @@ ROI_TIFF="${DATA_DIR}/0.roi/roi_convex_hull.tiff"     # ROI extent: downloaded o
 
 ```bash
 mkdir -p "${DATA_DIR}/0.roi"
-"${PYTHON_ENV}" tessera_preprocessing/convert_shp_to_tiff.py \
+python tessera_preprocessing/convert_shp_to_tiff.py \
     --shp_path   "${DATA_DIR}/0.roi/roi.shp" \
     --pixel_size 10
 ```
@@ -218,7 +218,7 @@ Writes `roi.tiff` and `roi_convex_hull.tiff` beside the shapefile. `ROI_TIFF` ab
 
 ### Step 1 — Download Sentinel-1 & Sentinel-2 → `1.data_sar_raw/`, `1.data_raw/`
 
-The network-heavy step and **the one most likely to fail partway**. It is safe to re-run: completed partitions are skipped, so just paste the block again to fetch only what is missing.
+The network-heavy step and **the one most likely to fail partway**. It is safe to re-run: with `S1_OVERWRITE=false` / `S2_OVERWRITE=false` (set below), each observation day whose per-date output already exists *and* validates is skipped, so re-pasting the block fetches only the missing days — completed work is never re-downloaded.
 
 ```bash
 INPUT_TIFF="${ROI_TIFF}" \
@@ -229,6 +229,8 @@ YEAR="${YEAR}" \
 DATA_SOURCE=mpc \
 S1_RAW_SUBDIR=1.data_sar_raw \
 S2_RAW_SUBDIR=1.data_raw \
+S1_OVERWRITE=false \
+S2_OVERWRITE=false \
     bash tessera_preprocessing/s1_s2_downloader.sh
 ```
 
@@ -237,6 +239,7 @@ Outputs: S1 → `${DATA_DIR}/1.data_sar_raw`, S2 → `${DATA_DIR}/1.data_raw`.
 - `INPUT_TIFF` / `OUT_DIR` / `TEMP_DIR` / `PYTHON_ENV` / `YEAR` — the ROI to download over, data root, scratch dir, interpreter, and year.
 - `DATA_SOURCE` — `mpc` (Microsoft Planetary Computer) or `aws`. For `aws`, Sentinel-1 needs an Earthdata bearer token at `~/.edl_bearer_token` (see the AWS Credentials section below).
 - `S1_RAW_SUBDIR` / `S2_RAW_SUBDIR` — output folder names (optional, default `data_sar_raw` / `data_raw`).
+- `S1_OVERWRITE` / `S2_OVERWRITE` — kept `false` here so a re-run *resumes*: each day's output is skipped if it already exists **and** passes a shape/CRS/transform check (the guard lives in `process_day_orbit` / `process_day`), so only missing or invalid days are re-fetched. Set `true` to force a full clean re-download (the script default) — rarely needed, since invalid tiles are already re-fetched automatically.
 - Advanced knobs inside `s1_s2_downloader.sh` (edit only if needed): `S1_PARTITIONS` / `S2_PARTITIONS` (time-slice parallelism), `S1_TOTAL_WORKERS` / `S2_TOTAL_WORKERS` (Dask workers), `START_TIME_OVERRIDE` / `END_TIME_OVERRIDE` (download a sub-range for a quick test).
 
 ### Step 2 — Stack into yearly composites → `2.data_processed/`
@@ -259,7 +262,7 @@ Stacks the Step 1 outputs along the time dimension into `.npy` composites under 
 ### Step 3 — Patchify into tiles → `3.retiled_d_pixel/`
 
 ```bash
-"${PYTHON_ENV}" tessera_preprocessing/dpixel_retiler.py \
+python tessera_preprocessing/dpixel_retiler.py \
     --tiff_path   "${ROI_TIFF}" \
     --d_pixel_dir "${DATA_DIR}/2.data_processed" \
     --out_dir     "${DATA_DIR}/3.retiled_d_pixel" \
@@ -278,7 +281,7 @@ Stacks the Step 1 outputs along the time dimension into `.npy` composites under 
 
 ```bash
 mkdir -p "${DATA_DIR}/4.embeddings_v2"
-"${PYTHON_ENV}" tessera_infer_v2/infer_v2.py \
+python tessera_infer_v2/infer_v2.py \
     --model     medium \
     --data-root "${DATA_DIR}/3.retiled_d_pixel" \
     --out-dir   "${DATA_DIR}/4.embeddings_v2"
@@ -297,7 +300,7 @@ Writes one 128-d fp32 `.npy` per tile. Weights are fetched automatically from Hu
 mkdir -p "${DATA_DIR}/5.result"
 
 # 5a. stitch per-tile embeddings into one map
-"${PYTHON_ENV}" tessera_infer/stitch_tiled_representation.py \
+python tessera_infer/stitch_tiled_representation.py \
     --d_pixel_retiled_path        "${DATA_DIR}/3.retiled_d_pixel" \
     --representation_retiled_path "${DATA_DIR}/4.embeddings_v2" \
     --downstream_tiff             "${ROI_TIFF}" \
@@ -305,7 +308,7 @@ mkdir -p "${DATA_DIR}/5.result"
     --out_name                    "${BASENAME}"
 
 # 5b. convert the .npy to a viewable GeoTIFF
-"${PYTHON_ENV}" tessera_infer/convert_npy2tiff.py \
+python tessera_infer/convert_npy2tiff.py \
     --npy_path      "${DATA_DIR}/5.result/${BASENAME}.npy" \
     --ref_tiff_path "${ROI_TIFF}" \
     --out_dir       "${DATA_DIR}/5.result" \
@@ -321,15 +324,15 @@ The `.tif` takes its name from the `.npy`, so both land in `5.result/` as `${BAS
 
 Prefer two pastes over six? After running the variables block above (same shell session), the pipeline can also be driven with two copy-paste blocks.
 
-**Block A — ROI + download (Step 0 + Step 1).** This is the failure-prone part; re-paste it to retry any tiles that timed out.
+**Block A — ROI + download (Step 0 + Step 1).** This is the failure-prone part; because `overwrite=false`, re-pasting it resumes — only the days that failed or timed out are re-fetched.
 
 ```bash
 mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
-"${PYTHON_ENV}" tessera_preprocessing/convert_shp_to_tiff.py \
+python tessera_preprocessing/convert_shp_to_tiff.py \
     --shp_path "${DATA_DIR}/0.roi/roi.shp" --pixel_size 10
 INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \
 PYTHON_ENV="${PYTHON_ENV}" YEAR="${YEAR}" DATA_SOURCE=mpc \
-S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw \
+S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw S1_OVERWRITE=false S2_OVERWRITE=false \
     bash tessera_preprocessing/s1_s2_downloader.sh
 ```
 
@@ -339,19 +342,19 @@ S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw \
 BASE_DIR="${DATA_DIR}" DOWNSAMPLE_RATE=1 \
 S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw PROCESSED_SUBDIR=2.data_processed \
     bash tessera_preprocessing/s1_s2_stacker.sh
-"${PYTHON_ENV}" tessera_preprocessing/dpixel_retiler.py \
+python tessera_preprocessing/dpixel_retiler.py \
     --tiff_path "${ROI_TIFF}" --d_pixel_dir "${DATA_DIR}/2.data_processed" \
     --out_dir "${DATA_DIR}/3.retiled_d_pixel" \
     --patch_size 500 --block_size 2000 --num_workers 16 --overwrite
 mkdir -p "${DATA_DIR}/4.embeddings_v2"
-"${PYTHON_ENV}" tessera_infer_v2/infer_v2.py \
+python tessera_infer_v2/infer_v2.py \
     --model medium --data-root "${DATA_DIR}/3.retiled_d_pixel" --out-dir "${DATA_DIR}/4.embeddings_v2"
 mkdir -p "${DATA_DIR}/5.result"
-"${PYTHON_ENV}" tessera_infer/stitch_tiled_representation.py \
+python tessera_infer/stitch_tiled_representation.py \
     --d_pixel_retiled_path "${DATA_DIR}/3.retiled_d_pixel" \
     --representation_retiled_path "${DATA_DIR}/4.embeddings_v2" \
     --downstream_tiff "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --out_name "${BASENAME}"
-"${PYTHON_ENV}" tessera_infer/convert_npy2tiff.py \
+python tessera_infer/convert_npy2tiff.py \
     --npy_path "${DATA_DIR}/5.result/${BASENAME}.npy" \
     --ref_tiff_path "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --downsample_rate 1
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
       - [Acceptable Use Policy](#AUP)
       - [Accessing Precomputed Embeddings](#global-embeddings-access)
       - [Creating Your Own Embeddings](#creating-your-own-embeddings)
+          - [End-to-end runbook](#end-to-end-runbook)
       - [Inference](#inference)
           - [TESSERA v2 (recommended)](#tessera-v2-recommended)
           - [TESSERA v1.1](#tessera-v11-qat-int8)
@@ -152,6 +153,208 @@ The pipeline has no strict requirements for CPU and GPU, but more CPU cores and 
 For the data preprocessing pipeline, we support almost all Linux systems. For Windows, we recommend using WSL. We do not support MacOS at this point.
 
 For the model inference part, we have only tested it on Linux and Windows WSL, and they are working.
+
+## End-to-end runbook
+
+The fastest path from a region of interest to a TESSERA v2 representation map. Every step runs from the **repository root** — there is no need to `cd` anywhere or edit any script: all paths and tuning knobs are passed as environment variables or CLI flags. Each step writes into a numbered folder under your data directory so the outputs stay ordered (`0.roi/`, `1.data_raw/`, …, `5.result/`).
+
+> The [Data Preprocessing](#data-preprocessing) and [Inference](#inference) sections below remain the detailed reference for each stage and the other model versions. This runbook is the complete, streamlined chain.
+
+### Setup (one-time)
+
+The pipeline needs a Python environment with the base repo dependencies (geoprocessing), PyTorch, and the v2 package + weights. Run this once — it `cd`s into `tessera_infer_v2` and `cd ..` back to the repo root afterwards, so the steps below still run from the root:
+
+```bash
+# (optional) create + activate a virtualenv — a conda env works too
+python3 -m venv venv
+source venv/bin/activate
+
+# base repo dependencies (geoprocessing: rasterio, fiona, …)
+pip install -r requirements.txt
+
+# PyTorch — match your CUDA version (see https://pytorch.org/)
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+
+# v2 inference deps + the default Medium checkpoint (~84 MB)
+cd tessera_infer_v2
+pip install -r requirements.txt
+python download_weights.py --model medium
+cd ..
+```
+
+> [!NOTE]
+> If the base `pip install -r requirements.txt` fails while building **fiona** with a `gdal-config not found` (or similar GDAL) error, install the system GDAL libraries and re-run that line:
+> ```bash
+> sudo apt install gdal-bin libgdal-dev
+> ```
+
+This fetches the recommended **Medium** student into `tessera_infer_v2/student/checkpoints/`. For the other students (Nano/Small/Large), the 2B teacher, or direct Hugging Face access, see [TESSERA v2 (recommended)](#tessera-v2-recommended).
+
+**Run this once in your terminal** — the variables are reused by every step. Keep the same shell session so they persist (which also makes retrying a step a single re-paste):
+
+```bash
+DATA_DIR=/absolute/path/to/your/data_dir              # all outputs are written under here
+PYTHON_ENV=/absolute/path/to/your/python_env/bin/python
+BASENAME=myregion_2024                                # final result file name (.npy and .tif)
+YEAR=2024                                             # data year, range [2017-2025]
+ROI_TIFF="${DATA_DIR}/0.roi/roi_convex_hull.tiff"     # ROI extent: downloaded over + used as geo-reference
+```
+
+### Step 0 — Shapefile → ROI GeoTIFF *(skip if you already have a GeoTIFF)* → `0.roi/`
+
+```bash
+mkdir -p "${DATA_DIR}/0.roi"
+"${PYTHON_ENV}" tessera_preprocessing/convert_shp_to_tiff.py \
+    --shp_path   "${DATA_DIR}/0.roi/roi.shp" \
+    --pixel_size 10
+```
+
+Writes `roi.tiff` and `roi_convex_hull.tiff` beside the shapefile. `ROI_TIFF` above points at the convex-hull file — that is the extent the next step downloads over.
+
+- `--shp_path` — your input shapefile.
+- `--pixel_size` — metres per pixel (optional, default `10`).
+- `--tiff_path` — custom output name (optional).
+- `--force_crs EPSG:32650` — force a target CRS instead of the auto-detected best UTM zone (optional).
+
+### Step 1 — Download Sentinel-1 & Sentinel-2 → `1.data_sar_raw/`, `1.data_raw/`
+
+The network-heavy step and **the one most likely to fail partway**. It is safe to re-run: completed partitions are skipped, so just paste the block again to fetch only what is missing.
+
+```bash
+INPUT_TIFF="${ROI_TIFF}" \
+OUT_DIR="${DATA_DIR}" \
+TEMP_DIR="${DATA_DIR}/tmp" \
+PYTHON_ENV="${PYTHON_ENV}" \
+YEAR="${YEAR}" \
+DATA_SOURCE=mpc \
+S1_RAW_SUBDIR=1.data_sar_raw \
+S2_RAW_SUBDIR=1.data_raw \
+    bash tessera_preprocessing/s1_s2_downloader.sh
+```
+
+Outputs: S1 → `${DATA_DIR}/1.data_sar_raw`, S2 → `${DATA_DIR}/1.data_raw`.
+
+- `INPUT_TIFF` / `OUT_DIR` / `TEMP_DIR` / `PYTHON_ENV` / `YEAR` — the ROI to download over, data root, scratch dir, interpreter, and year.
+- `DATA_SOURCE` — `mpc` (Microsoft Planetary Computer) or `aws`. For `aws`, Sentinel-1 needs an Earthdata bearer token at `~/.edl_bearer_token` (see the AWS Credentials section below).
+- `S1_RAW_SUBDIR` / `S2_RAW_SUBDIR` — output folder names (optional, default `data_sar_raw` / `data_raw`).
+- Advanced knobs inside `s1_s2_downloader.sh` (edit only if needed): `S1_PARTITIONS` / `S2_PARTITIONS` (time-slice parallelism), `S1_TOTAL_WORKERS` / `S2_TOTAL_WORKERS` (Dask workers), `START_TIME_OVERRIDE` / `END_TIME_OVERRIDE` (download a sub-range for a quick test).
+
+### Step 2 — Stack into yearly composites → `2.data_processed/`
+
+```bash
+BASE_DIR="${DATA_DIR}" \
+DOWNSAMPLE_RATE=1 \
+S1_RAW_SUBDIR=1.data_sar_raw \
+S2_RAW_SUBDIR=1.data_raw \
+PROCESSED_SUBDIR=2.data_processed \
+    bash tessera_preprocessing/s1_s2_stacker.sh
+```
+
+Stacks the Step 1 outputs along the time dimension into `.npy` composites under `${DATA_DIR}/2.data_processed`. Fast (Rust binaries).
+
+- `BASE_DIR` — data root (same as Step 1's `OUT_DIR`).
+- `DOWNSAMPLE_RATE` — `1` keeps full 10 m resolution (optional, default `1`).
+- `S1_RAW_SUBDIR` / `S2_RAW_SUBDIR` / `PROCESSED_SUBDIR` — the three folder names; must match Step 1 (optional, default `data_sar_raw` / `data_raw` / `data_processed`).
+
+### Step 3 — Patchify into tiles → `3.retiled_d_pixel/`
+
+```bash
+"${PYTHON_ENV}" tessera_preprocessing/dpixel_retiler.py \
+    --tiff_path   "${ROI_TIFF}" \
+    --d_pixel_dir "${DATA_DIR}/2.data_processed" \
+    --out_dir     "${DATA_DIR}/3.retiled_d_pixel" \
+    --patch_size  500 \
+    --block_size  2000 \
+    --num_workers 16 \
+    --overwrite
+```
+
+- `--tiff_path` — reference TIFF defining the grid; `--d_pixel_dir` — Step 2 output; `--out_dir` — where tiles are written.
+- `--patch_size` / `--block_size` — tile and super-block size in px (optional, default `500` / `2000`; good starting point for a ~5000×5000 px ROI at 10 m).
+- `--num_workers` — parallel workers (optional, default `16`).
+- `--overwrite` — wipe `out_dir` first; drop it to resume without re-doing finished patches (or use `--skip_existing`).
+
+### Step 4 — TESSERA v2 inference → `4.embeddings_v2/`
+
+```bash
+mkdir -p "${DATA_DIR}/4.embeddings_v2"
+"${PYTHON_ENV}" tessera_infer_v2/infer_v2.py \
+    --model     medium \
+    --data-root "${DATA_DIR}/3.retiled_d_pixel" \
+    --out-dir   "${DATA_DIR}/4.embeddings_v2"
+```
+
+Writes one 128-d fp32 `.npy` per tile. Weights are fetched automatically from Hugging Face on first use (or run `python tessera_infer_v2/download_weights.py --model medium` beforehand).
+
+- `--model` — `nano` / `small` / `medium` (default) / `large` / `teacher`; `--data-root` — Step 3 output; `--out-dir` — embeddings directory.
+- `--device` — `cuda` (default if available) or `cpu`.
+- `--batch-pixels` — pixels per forward pass; lower it if you run out of memory (optional, default `4096`).
+- `--dim 16 --int8` — store a Matryoshka prefix as int8 + a scale map (much smaller). Other versions (v1.1 / v1.0) are documented under [Inference](#inference).
+
+### Step 5 — Stitch & convert → `5.result/<BASENAME>.npy`, `5.result/<BASENAME>.tif`
+
+```bash
+mkdir -p "${DATA_DIR}/5.result"
+
+# 5a. stitch per-tile embeddings into one map
+"${PYTHON_ENV}" tessera_infer/stitch_tiled_representation.py \
+    --d_pixel_retiled_path        "${DATA_DIR}/3.retiled_d_pixel" \
+    --representation_retiled_path "${DATA_DIR}/4.embeddings_v2" \
+    --downstream_tiff             "${ROI_TIFF}" \
+    --out_dir                     "${DATA_DIR}/5.result" \
+    --out_name                    "${BASENAME}"
+
+# 5b. convert the .npy to a viewable GeoTIFF
+"${PYTHON_ENV}" tessera_infer/convert_npy2tiff.py \
+    --npy_path      "${DATA_DIR}/5.result/${BASENAME}.npy" \
+    --ref_tiff_path "${ROI_TIFF}" \
+    --out_dir       "${DATA_DIR}/5.result" \
+    --downsample_rate 1
+```
+
+The `.tif` takes its name from the `.npy`, so both land in `5.result/` as `${BASENAME}.npy` and `${BASENAME}.tif`. Open the `.tif` in QGIS to inspect.
+
+- Stitch — `--d_pixel_retiled_path` (Step 3) + `--representation_retiled_path` (Step 4) + `--downstream_tiff` (output extent) + `--out_dir`; `--out_name` sets the basename (optional, default `stitched_representation`).
+- Convert — `--npy_path` (Step 5a output), `--ref_tiff_path` (supplies CRS + geotransform), `--out_dir`; `--downsample_rate` coarsens the output — `2` → 20 m (optional, default `1`).
+
+### One-click blocks
+
+Prefer two pastes over six? After running the variables block above (same shell session), the pipeline can also be driven with two copy-paste blocks.
+
+**Block A — ROI + download (Step 0 + Step 1).** This is the failure-prone part; re-paste it to retry any tiles that timed out.
+
+```bash
+mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
+"${PYTHON_ENV}" tessera_preprocessing/convert_shp_to_tiff.py \
+    --shp_path "${DATA_DIR}/0.roi/roi.shp" --pixel_size 10
+INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \
+PYTHON_ENV="${PYTHON_ENV}" YEAR="${YEAR}" DATA_SOURCE=mpc \
+S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw \
+    bash tessera_preprocessing/s1_s2_downloader.sh
+```
+
+**Block B — stack → result (Step 2 → Step 5).** Paste this once Step 1 has downloaded cleanly.
+
+```bash
+BASE_DIR="${DATA_DIR}" DOWNSAMPLE_RATE=1 \
+S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw PROCESSED_SUBDIR=2.data_processed \
+    bash tessera_preprocessing/s1_s2_stacker.sh
+"${PYTHON_ENV}" tessera_preprocessing/dpixel_retiler.py \
+    --tiff_path "${ROI_TIFF}" --d_pixel_dir "${DATA_DIR}/2.data_processed" \
+    --out_dir "${DATA_DIR}/3.retiled_d_pixel" \
+    --patch_size 500 --block_size 2000 --num_workers 16 --overwrite
+mkdir -p "${DATA_DIR}/4.embeddings_v2"
+"${PYTHON_ENV}" tessera_infer_v2/infer_v2.py \
+    --model medium --data-root "${DATA_DIR}/3.retiled_d_pixel" --out-dir "${DATA_DIR}/4.embeddings_v2"
+mkdir -p "${DATA_DIR}/5.result"
+"${PYTHON_ENV}" tessera_infer/stitch_tiled_representation.py \
+    --d_pixel_retiled_path "${DATA_DIR}/3.retiled_d_pixel" \
+    --representation_retiled_path "${DATA_DIR}/4.embeddings_v2" \
+    --downstream_tiff "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --out_name "${BASENAME}"
+"${PYTHON_ENV}" tessera_infer/convert_npy2tiff.py \
+    --npy_path "${DATA_DIR}/5.result/${BASENAME}.npy" \
+    --ref_tiff_path "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --downsample_rate 1
+```
 
 ## Data Preprocessing
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ The fastest path from a region of interest to a TESSERA v2 representation map. E
 
 > The [Data Preprocessing](#data-preprocessing) and [Inference](#inference) sections below remain the detailed reference for each stage and the other model versions. This runbook is the complete, streamlined chain.
 
-### Setup (one-time)
+### Setup environment
 
 The pipeline needs a Python environment with the base repo dependencies (geoprocessing), PyTorch, and the v2 package + weights. Run this once — it `cd`s into `tessera_infer_v2` and `cd ..` back to the repo root afterwards, so the steps below still run from the root:
 
 ```bash
-# (optional) create + activate a virtualenv — a conda env works too
+#  create + activate a virtualenv — a conda env works too
 python3 -m venv venv
 source venv/bin/activate
 
@@ -194,28 +194,24 @@ This fetches the recommended **Medium** student into `tessera_infer_v2/student/c
 
 ```bash
 DATA_DIR=/absolute/path/to/your/data_dir              # all outputs are written under here
-PYTHON_ENV=/absolute/path/to/your/python_env/bin/python  # absolute path to your interpreter; only the Step 1 downloader needs it
-BASENAME=myregion_2024                                # final result file name (.npy and .tif)
-YEAR=2024                                             # data year, range [2017-2025]
-ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
+ROI_SHP=/absolute/path/to/your/roi.shp
+PYTHON_ENV=/absolute/path/to/python_env/bin/python    # run `which python` when you have activated venv
+BASENAME=myregion                                     # final result file name (.npy and .tif)
+YEAR=2025                                             # data year, range [2017-2025]
 ```
 
 ### Step 0 — Prepare ROI GeoTIFF  → `0.roi/`
 
 ```bash
+ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
 mkdir -p "${DATA_DIR}/0.roi"
-# Copy your roi.tiff to ${DATA_DIR}/0.roi manually
-# cp /path/to/your/roi.shp "${DATA_DIR}/0.roi"
-
-# Or generate it from shapefile using script
-# Move your roi.shp to `0.roi` directory
-# mv /path/to/your/roi.shp "${DATA_DIR}/0.roi"
 python tessera_preprocessing/convert_shp_to_tiff.py \
-    --shp_path   "${DATA_DIR}/0.roi/roi.shp" \
+    --shp_path   "${ROI_SHP}" \
+    --tiff_path  "${ROI_TIFF}" \
     --pixel_size 10
 ```
 
-`tessera_preprocessing/convert_shp_to_tiff.py` writes `roi.tiff` and `roi_convex_hull.tiff` beside the shapefile. `ROI_TIFF` above points at the Geotiff file — that is the extent the next step downloads over.
+Commands above writes `roi.tiff` and `roi_convex_hull.tiff` to `0.roi/`. `ROI_TIFF` above points at the Geotiff file — that is the extent the next step downloads over.
 
 - `--shp_path` — your input shapefile.
 - `--pixel_size` — metres per pixel (optional, default `10`).
@@ -328,26 +324,32 @@ The `.tif` takes its name from the `.npy`, so both land in `5.result/` as `${BAS
 
 ### One-click blocks
 
-Prefer two pastes over six? After running the variables block above (same shell session), the pipeline can also be driven with two copy-paste blocks.
-
-**Block A — ROI + download (Step 0 + Step 1).** This is the failure-prone part; because `overwrite=false`, re-pasting it resumes — only the days that failed or timed out are re-fetched.
+Too much copy & paste? The pipeline can also be ran with fewer copy-paste blocks.(*you can run all blocks at once if the area of ROI is relatively small, e.g. $<400km^2$*)  
+**Block Config  —** Copy this and edit following configs, paste edited configs and run in shell
 
 ```bash
-mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
+DATA_DIR=/absolute/path/to/your/data_dir              # all outputs are written under here
+ROI_SHP=/absolute/path/to/your/roi.shp
+PYTHON_ENV=/absolute/path/to/python_env/bin/python    # absolute path to your interpreter; only the Step 1 downloader needs it
+BASENAME=myregion                                     # final result file name (.npy and .tif)
+YEAR=2025                                             # data year, range [2017-2025]
 ```
 
-Now place your shapefile in `"${DATA_DIR}/0.roi"` as `roi.shp`
+**Block A — ROI + download (Step 0 + Step 1).** This is the failure-prone part; because `overwrite=false`, re-run `bash tessera_preprocessing/s1_s2_downloader.sh` resumes — only the days that failed or timed out are re-fetched.
 
 ```bash
+ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
+mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
 python tessera_preprocessing/convert_shp_to_tiff.py \
-    --shp_path "${DATA_DIR}/0.roi/roi.shp" --pixel_size 10
+    --shp_path "${DATA_DIR}/0.roi/roi.shp" --tiff_path  "${ROI_TIFF}" --pixel_size 10
+
 INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \
 PYTHON_ENV="${PYTHON_ENV}" YEAR="${YEAR}" DATA_SOURCE=mpc \
 S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw S1_OVERWRITE=false S2_OVERWRITE=false \
     bash tessera_preprocessing/s1_s2_downloader.sh
 ```
 
-**Block B — stack → result (Step 2 → Step 5).** Paste this once Step 1 has downloaded cleanly.
+**Block B — stack → result (Step 2 → Step 5).** Paste and run this once Step 1 has downloaded cleanly.
 
 ```bash
 BASE_DIR="${DATA_DIR}" DOWNSAMPLE_RATE=1 \

--- a/README.md
+++ b/README.md
@@ -208,7 +208,16 @@ tessera_project
    ┗ roi.tiff (we recommend generating this using convert_shp_to_tiff.py)
 ```
 
-The `roi.tiff` can be generated using `convert_shp_to_tiff.py` located in `tessera_preprocessing/convert_shp_to_tiff.py`. To use it, simply specify the path to your shapefile in the main function, and it will output a TIFF with the same name in the same directory.
+The `roi.tiff` can be generated using `convert_shp_to_tiff.py` located in `tessera_preprocessing/convert_shp_to_tiff.py`:
+
+```bash
+cd tessera_preprocessing
+python convert_shp_to_tiff.py \
+    --shp_path   /absolute/path/to/your/data_dir/roi.shp \
+    --pixel_size 10
+```
+
+By default it writes a TIFF with the same name as the shapefile in the same directory (e.g. `roi.shp` → `roi.tiff`) and a `<name>_convex_hull.tiff` alongside it; override the destination with `--tiff_path`. Set `--pixel_size` in meters (default `10`), and optionally force a target CRS with `--force_crs EPSG:32650` (default: auto-detect the best UTM zone from the shapefile centroid).
 
 ⚠️Notice: _If your ROI is relatively large, for example 100 km × 100 km, we strongly recommend pre-splitting the TIFF into smaller sections no larger than 20 km × 20 km. Then process each small TIFF file sequentially in the pipeline. An excessively large ROI may cause issues with backend tile providers_
 
@@ -898,13 +907,27 @@ python stitch_tiled_representation.py \
 --out_dir /maps/usr/tessera_project/my_data
 ```
 
-Finally, you'll get a stitched representation map in the `my_data` directory with the shape (H,W,C), where H and W match your initial `roi.tiff` and C is the embedding dimension of the version you ran. The representation map is a NumPy array. If you want to convert it to TIFF for viewing in software like QGIS, you can use the `tessera_infer/convert_npy2tiff.py` script. Just modify the main function with:
+Finally, you'll get a stitched representation map in the `my_data` directory with the shape (H,W,C), where H and W match your initial `roi.tiff` and C is the embedding dimension of the version you ran. The representation map is a NumPy array. If you want to convert it to TIFF for viewing in software like QGIS, you can use the `tessera_infer/convert_npy2tiff.py` script:
 
-```python
-npy_path = "/maps/usr/tessera_project/my_data/stitched_representation.npy"  # Change to the actual npy file path
-ref_tiff_path = "/maps/usr/tessera_project/my_data/roi.tiff"  # Change to the actual reference tiff file path
-out_dir = "/maps/usr/tessera_project/my_data/"  # Change to the actual output directory
+```bash
+python convert_npy2tiff.py \
+    --npy_path      /path/to/stitched_representation.npy \
+    --ref_tiff_path /path/to/roi.tiff \
+    --out_dir       /path/to/output_directory \
+    --downsample_rate 1
 ```
+
+For example:
+
+```bash
+python convert_npy2tiff.py \
+    --npy_path      /maps/usr/tessera_project/my_data/stitched_representation.npy \
+    --ref_tiff_path /maps/usr/tessera_project/my_data/roi.tiff \
+    --out_dir       /maps/usr/tessera_project/my_data \
+    --downsample_rate 1
+```
+
+The output GeoTIFF borrows its CRS and geotransform from `--ref_tiff_path`. Set `--downsample_rate` (integer, area-average, default `1`) to coarsen the resolution — e.g. `2` produces a 20m output.
 
 ## Downstream tasks
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ YEAR=2025                                             # data year, range [2017-2
 ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
 mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
 python tessera_preprocessing/convert_shp_to_tiff.py \
-    --shp_path "${DATA_DIR}/0.roi/roi.shp" --tiff_path  "${ROI_TIFF}" --pixel_size 10
+    --shp_path "${ROI_SHP}" --tiff_path  "${ROI_TIFF}" --pixel_size 10
 
 INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \
 PYTHON_ENV="${PYTHON_ENV}" YEAR="${YEAR}" DATA_SOURCE=mpc \

--- a/runbook.sh
+++ b/runbook.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e  # Any step fails, exit the script
+
+## CONFIG
+BASENAME=region                                       # final result file name (.npy and .tif)
+YEAR=2025                                             # data year, range [2017-2025]
+BASE=/abs/path/to/my_data                             # full path  to base dir, all files go here
+RESOLUTION=10                                         # resolution for download and process
+
+ROI_SHP="${BASE}/${BASENAME}.shp"                     # path to your shapefile
+DATA_DIR="${BASE}/${BASENAME}_${YEAR}"                # path to store all data
+
+PYTHON_ENV=`which python` # absolute path to your interpreter; only the Step 1 downloader needs it
+
+## STEP 0
+ROI_TIFF="${DATA_DIR}/0.roi/roi.tiff"     # ROI extent: downloaded over + used as geo-reference
+mkdir -p "${DATA_DIR}/0.roi" "${DATA_DIR}/tmp"
+python tessera_preprocessing/convert_shp_to_tiff.py \
+    --shp_path "${ROI_SHP}" --tiff_path  "${ROI_TIFF}" --pixel_size "${RESOLUTION}"
+
+## STEP 1
+INPUT_TIFF="${ROI_TIFF}" OUT_DIR="${DATA_DIR}" TEMP_DIR="${DATA_DIR}/tmp" \
+PYTHON_ENV="${PYTHON_ENV}" YEAR="${YEAR}" DATA_SOURCE=mpc RESOLUTION="${RESOLUTION}" \
+S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw S1_OVERWRITE=false S2_OVERWRITE=false \
+    bash tessera_preprocessing/s1_s2_downloader.sh
+	
+## STEP 2
+BASE_DIR="${DATA_DIR}" DOWNSAMPLE_RATE=1 \
+S1_RAW_SUBDIR=1.data_sar_raw S2_RAW_SUBDIR=1.data_raw PROCESSED_SUBDIR=2.data_processed \
+    bash tessera_preprocessing/s1_s2_stacker.sh
+
+## STEP 3
+python tessera_preprocessing/dpixel_retiler.py \
+    --tiff_path "${ROI_TIFF}" --d_pixel_dir "${DATA_DIR}/2.data_processed" \
+    --out_dir "${DATA_DIR}/3.retiled_d_pixel" \
+    --patch_size 500 --block_size 2000 --num_workers 16 --overwrite
+
+## STEP 4
+mkdir -p "${DATA_DIR}/4.embeddings_v2"
+python tessera_infer_v2/infer_v2.py \
+    --model medium --data-root "${DATA_DIR}/3.retiled_d_pixel" --out-dir "${DATA_DIR}/4.embeddings_v2"
+
+## STEP 5
+mkdir -p "${DATA_DIR}/5.result"
+python tessera_infer/stitch_tiled_representation.py \
+    --d_pixel_retiled_path "${DATA_DIR}/3.retiled_d_pixel" \
+    --representation_retiled_path "${DATA_DIR}/4.embeddings_v2" \
+    --downstream_tiff "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --out_name "${BASENAME}"
+python tessera_infer/convert_npy2tiff.py \
+    --npy_path "${DATA_DIR}/5.result/${BASENAME}.npy" \
+    --ref_tiff_path "${ROI_TIFF}" --out_dir "${DATA_DIR}/5.result" --downsample_rate 1

--- a/tessera_infer/convert_npy2tiff.py
+++ b/tessera_infer/convert_npy2tiff.py
@@ -74,9 +74,18 @@ def convert_npy_to_tiff(npy_path, ref_tiff_path, out_dir, downsample_rate=1):
     print(f"Output file saved as: {out_path}")
     print(f"Resolution: Original 10m, after downsampling {10 * downsample_rate}m")
 
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Convert a TESSERA representation .npy file (H,W,C) to a GeoTIFF, borrowing CRS/transform from a reference TIFF')
+    parser.add_argument('--npy_path', required=True, help='Path to the input .npy file (shape H,W,C)')
+    parser.add_argument('--ref_tiff_path', required=True, help='Path to the reference TIFF file providing CRS/transform')
+    parser.add_argument('--out_dir', required=True, help='Output directory for the generated GeoTIFF')
+    parser.add_argument('--downsample_rate', type=int, default=1, help='Downsampling rate (area averaging). 1 = no downsampling (default: 1)')
+
+    args = parser.parse_args()
+
+    convert_npy_to_tiff(args.npy_path, args.ref_tiff_path, args.out_dir, args.downsample_rate)
+
 if __name__ == "__main__":
-    npy_path = "/scratch/zf281/tessera/data/cambridge/output/2024/stitched_representation.npy"  # Change to the actual npy file path
-    ref_tiff_path = "/scratch/zf281/tessera/data/cambridge/geoinfo/CB.tiff"  # Change to the actual reference tiff file path
-    out_dir = "/scratch/zf281/tessera/data/cambridge/output/2024"  # Change to the actual output directory
-    downsample_rate = 1  # Default is no downsampling, modify as needed
-    convert_npy_to_tiff(npy_path, ref_tiff_path, out_dir, downsample_rate)
+    main()

--- a/tessera_infer/convert_npy2tiff.py
+++ b/tessera_infer/convert_npy2tiff.py
@@ -59,6 +59,7 @@ def convert_npy_to_tiff(npy_path, ref_tiff_path, out_dir, downsample_rate=1):
         'width': W,
         'count': C,
         'dtype': data.dtype,
+        'nodata': 0,            # Set 0 as nodata
         'transform': transform  # Update affine transform information
     })
 

--- a/tessera_infer/convert_npy2tiff.py
+++ b/tessera_infer/convert_npy2tiff.py
@@ -40,6 +40,8 @@ def convert_npy_to_tiff(npy_path, ref_tiff_path, out_dir, downsample_rate=1):
         # Keep the coordinate system and affine transform information from the reference tiff
         transform = ref.transform
         crs = ref.crs
+        # Get ref tiff file resolution
+        resolution = ref.res[0]
 
         # If downsampling is needed, modify the pixel size in the affine transform
         if downsample_rate > 1:
@@ -72,7 +74,7 @@ def convert_npy_to_tiff(npy_path, ref_tiff_path, out_dir, downsample_rate=1):
             print(f"Band {i + 1} writing complete")
 
     print(f"Output file saved as: {out_path}")
-    print(f"Resolution: Original 10m, after downsampling {10 * downsample_rate}m")
+    print(f"Resolution: Original {resolution}m, after downsampling {resolution * downsample_rate}m")
 
 def main():
     import argparse

--- a/tessera_infer/stitch_tiled_representation.py
+++ b/tessera_infer/stitch_tiled_representation.py
@@ -41,7 +41,7 @@ def check_intersection(folder_info):
         'roi_height': roi_height,
     }
 
-def stitch_and_crop_representations(d_pixel_retiled_path, representation_retiled_path, downstream_tiff_path, out_dir):
+def stitch_and_crop_representations(d_pixel_retiled_path, representation_retiled_path, downstream_tiff_path, out_dir, out_name="stitched_representation"):
     """
     Optimized version: Stitch representation vectors and crop to the downstream TIFF extent.
     
@@ -242,7 +242,7 @@ def stitch_and_crop_representations(d_pixel_retiled_path, representation_retiled
     os.makedirs(out_dir, exist_ok=True)
     
     # Save as numpy file
-    out_path = os.path.join(out_dir, "stitched_representation.npy")
+    out_path = os.path.join(out_dir, f"{out_name}.npy")
     print(f"Saving to: {out_path}")
     np.save(out_path, target_array)
     
@@ -267,6 +267,7 @@ def main():
     parser.add_argument('--representation_retiled_path', required=True, help='Directory path containing representation vector npy files')
     parser.add_argument('--downstream_tiff', required=True, help='Path to the downstream TIFF file')
     parser.add_argument('--out_dir', required=True, help='Output directory')
+    parser.add_argument('--out_name', default='stitched_representation', help='Output .npy basename (no extension); convert_npy2tiff.py reuses it for the .tif')
     
     args = parser.parse_args()
     
@@ -274,7 +275,8 @@ def main():
         args.d_pixel_retiled_path,
         args.representation_retiled_path,
         args.downstream_tiff,
-        args.out_dir
+        args.out_dir,
+        args.out_name
     )
 
 if __name__ == "__main__":

--- a/tessera_preprocessing/convert_shp_to_tiff.py
+++ b/tessera_preprocessing/convert_shp_to_tiff.py
@@ -257,15 +257,25 @@ def shp_to_tiff(shp_path, tiff_path=None, pixel_size=100, force_crs=None):
     return tiff_path, hull_tiff_path
 
 def main():
-    """
-    Main function to run the conversion process.
-    """
-    # Input shapefile path
-    shp_path = 'absolute_path_to_your_shp_file'
+    import argparse
 
-    # Call the conversion function
+    parser = argparse.ArgumentParser(description='Convert a shapefile (.shp) to a TIFF raster ROI mask, automatically selecting the best UTM CRS')
+    parser.add_argument('--shp_path', required=True, help='Path to the input shapefile (.shp)')
+    parser.add_argument('--tiff_path', default=None, help='Path to the output TIFF (default: same name as the shapefile, same directory, .tiff extension)')
+    parser.add_argument('--pixel_size', type=float, default=10, help='Output pixel size in meters (default: 10)')
+    parser.add_argument('--force_crs', default=None, help='Force a specific target CRS, e.g. EPSG:32650 (default: auto-detect best UTM zone)')
+
+    args = parser.parse_args()
+
+    force_crs = CRS.from_user_input(args.force_crs) if args.force_crs else None
+
     try:
-        tiff_path, hull_tiff_path = shp_to_tiff(shp_path, pixel_size=10, force_crs=None)
+        tiff_path, hull_tiff_path = shp_to_tiff(
+            args.shp_path,
+            tiff_path=args.tiff_path,
+            pixel_size=args.pixel_size,
+            force_crs=force_crs,
+        )
         logger.info(f"Conversion complete!")
         logger.info(f"TIFF file saved at: {tiff_path}")
         logger.info(f"Convex hull TIFF saved at: {hull_tiff_path}")

--- a/tessera_preprocessing/s1_s2_downloader.sh
+++ b/tessera_preprocessing/s1_s2_downloader.sh
@@ -7,6 +7,10 @@
 # set -euo pipefail
 set -u
 
+# Resolve this script's own directory so the sibling *.py processors can be
+# located regardless of where the script is invoked from (no `cd` required).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 #######################################
 # USER CONFIGURABLE PARAMETERS
 #######################################
@@ -75,8 +79,10 @@ SCRIPT_START_TIME=$(date +%s)
 SCRIPT_NAME=$(basename "$0")
 LOG_DIR="${OUT_DIR}/logs"
 MAIN_LOG="${LOG_DIR}/tessera_processing_$(date +%Y%m%d_%H%M%S).log"
-S1_OUTPUT="${OUT_DIR}/data_sar_raw"
-S2_OUTPUT="${OUT_DIR}/data_raw"
+ : "${S1_RAW_SUBDIR:=data_sar_raw}"   # S1 raw output subdir under OUT_DIR (read by the stacker)
+ : "${S2_RAW_SUBDIR:=data_raw}"       # S2 raw output subdir under OUT_DIR (read by the stacker)
+S1_OUTPUT="${OUT_DIR}/${S1_RAW_SUBDIR}"
+S2_OUTPUT="${OUT_DIR}/${S2_RAW_SUBDIR}"
 
 # Color definitions
 RED='\033[0;31m'
@@ -325,7 +331,7 @@ process_sentinel1() {
         local debug_flag=""
         [[ "$DEBUG" == "true" ]] && debug_flag="--debug"
         
-        $PYTHON_ENV s1_fast_processor.py \
+        $PYTHON_ENV "$SCRIPT_DIR/s1_fast_processor.py" \
             --input_tiff "$INPUT_TIFF" \
             --start_date "$p_start" \
             --end_date "$p_end" \
@@ -410,7 +416,7 @@ process_sentinel2() {
         local s2_start="${p_start}T00:00:00"
         local s2_end="${p_end}T23:59:59"
         
-        $PYTHON_ENV s2_fast_processor.py \
+        $PYTHON_ENV "$SCRIPT_DIR/s2_fast_processor.py" \
             --input_tiff "$INPUT_TIFF" \
             --start_date "$s2_start" \
             --end_date "$s2_end" \
@@ -484,12 +490,12 @@ main() {
     fi
     
     # Check Python scripts
-    if [[ "$S1_ENABLED" == "true" && ! -f "s1_fast_processor.py" ]]; then
+    if [[ "$S1_ENABLED" == "true" && ! -f "$SCRIPT_DIR/s1_fast_processor.py" ]]; then
         log ERROR "S1 processor script not found: s1_fast_processor.py"
         exit 1
     fi
     
-    if [[ "$S2_ENABLED" == "true" && ! -f "s2_fast_processor.py" ]]; then
+    if [[ "$S2_ENABLED" == "true" && ! -f "$SCRIPT_DIR/s2_fast_processor.py" ]]; then
         log ERROR "S2 processor script not found: s2_fast_processor.py"
         exit 1
     fi

--- a/tessera_preprocessing/s1_s2_downloader.sh
+++ b/tessera_preprocessing/s1_s2_downloader.sh
@@ -52,7 +52,8 @@ S1_CHUNKSIZE=1024                  # S1 stackstac chunk size
 S1_ORBIT_STATE="both"              # Orbit state: ascending/descending/both
 S1_MIN_COVERAGE=0.01               # Minimum valid pixel coverage for S1 (%) set this to 0.01 to mitigate the tiling artefact!
 S1_RESOLUTION=$RESOLUTION          # S1 output resolution (meters)
-S1_OVERWRITE=true                  # Overwrite existing S1 files
+: "${S1_OVERWRITE:=true}"          # Overwrite existing S1 files
+
 
 # === Sentinel-2 Configuration ===
 S2_ENABLED=true                    # Enable S2 processing
@@ -63,7 +64,8 @@ S2_CHUNKSIZE=1024                  # S2 stackstac chunk size
 S2_MAX_CLOUD=100                   # Maximum cloud coverage for S2 (%) set this to 100 to mitigate the tiling artefact!
 S2_RESOLUTION=$RESOLUTION          # S2 output resolution (meters)
 S2_MIN_COVERAGE=0.01               # Minimum valid pixel coverage for S2 (%) set this to 0.01 to mitigate the tiling artefact!
-S2_OVERWRITE=true                  # Overwrite existing S2 files
+: "${S2_OVERWRITE:=true}"          # Overwrite existing S2 files
+
 
 # === System Configuration ===
 DEBUG=false                        # Enable debug mode

--- a/tessera_preprocessing/s1_s2_stacker.sh
+++ b/tessera_preprocessing/s1_s2_stacker.sh
@@ -7,15 +7,23 @@
 # set -euo pipefail
 set -u
 
+# Resolve this script's own directory so the sibling s1_stack / s2_stack
+# binaries can be located regardless of where the script is invoked from
+# (no `cd` required).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 #######################################
 # USER CONFIGURABLE PARAMETERS
 #######################################
 
 # === Basic Configuration ===
-# BASE_DIR="/absolute/path/to/your/data_dir"
-BASE_DIR="/scratch/zf281/tessera/data/cambridge/output/2024"
-OUT_DIR="${BASE_DIR}/data_processed"
-DOWNSAMPLE_RATE=1
+ : "${BASE_DIR:=/absolute/path/to/your/data_dir}"
+#BASE_DIR="/scratch/zf281/tessera/data/cambridge/output/2024"
+ : "${S1_RAW_SUBDIR:=data_sar_raw}"      # S1 raw input subdir under BASE_DIR (matches the downloader output)
+ : "${S2_RAW_SUBDIR:=data_raw}"          # S2 raw input subdir under BASE_DIR (matches the downloader output)
+ : "${PROCESSED_SUBDIR:=data_processed}" # stacked output subdir under BASE_DIR
+OUT_DIR="${BASE_DIR}/${PROCESSED_SUBDIR}"
+ : "${DOWNSAMPLE_RATE:=1}"
 
 mkdir -p "$OUT_DIR"
 
@@ -38,8 +46,8 @@ OPTIONS:
     -r, --rate <rate>                Downsampling rate (e.g., 10 means take every 10th pixel) [default: 10]
 '
 
-./s1_stack \
-  --input-dir "${BASE_DIR}/data_sar_raw" \
+"$SCRIPT_DIR/s1_stack" \
+  --input-dir "${BASE_DIR}/${S1_RAW_SUBDIR}" \
   --output-dir $OUT_DIR \
   --parallel 16 \
   --rate $DOWNSAMPLE_RATE
@@ -65,8 +73,8 @@ OPTIONS:
     -r, --sample-rate <sample-rate>    Downsample rate (default=10) [default: 10]
 '
 
-./s2_stack \
-  --input "${BASE_DIR}/data_raw" \
+"$SCRIPT_DIR/s2_stack" \
+  --input "${BASE_DIR}/${S2_RAW_SUBDIR}" \
   --output $OUT_DIR \
   --batch-size 16 \
   --cache-level 1 \


### PR DESCRIPTION
Both preprocessing shell scripts required `cd tessera_preprocessing` before
they would find their sibling processors/binaries, and their output
subdirectories were hardcoded. Resolve SCRIPT_DIR so each can be invoked from
anywhere, expose the output subdirectories as env vars so the layout lines up
across steps, and add a runnable end-to-end runbook to the README.

- `s1_s2_downloader.sh`: resolve SCRIPT_DIR and invoke `s1/s2_fast_processor.py`
  (plus the existence checks) via "$SCRIPT_DIR/...". Expose S1_RAW_SUBDIR /
  S2_RAW_SUBDIR (defaults data_sar_raw / data_raw) so the raw-output layout is
  configurable and matches what the stacker reads.
- `s1_s2_stacker.sh`: resolve SCRIPT_DIR and invoke "$SCRIPT_DIR/s1_stack" /
  "$SCRIPT_DIR/s2_stack". Make BASE_DIR, S1_RAW_SUBDIR, S2_RAW_SUBDIR,
  PROCESSED_SUBDIR and DOWNSAMPLE_RATE env-var overridable, so the stacker
  picks up the downloader's output layout automatically and produces a
  step-numbered data_processed dir.
- `stitch_tiled_representation.py`: add --out_name (default
  stitched_representation) so the final .npy/.tif can be named after the
  region/year; convert_npy2tiff.py already reuses the npy basename for the .tif.
- `README`: add an "End-to-end runbook" section — one-time setup (venv, base deps
  with a fiona / gdal-config install note, PyTorch, v2 deps + Medium weights),
  a shared variable block, step-numbered commands (Step 0-5 → 0.roi /
  1.data_* / 2.data_processed / 3.retiled_d_pixel / 4.embeddings_v2 /
  5.result), and two one-click copy-paste blocks.

Co-Authored-By: GLM-5 <noreply@z.ai>