### PR TITLE
README: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ If you use TESSERA in your research, please cite the relevant paper(s).
 We would like to express our gratitude to UKRI, the [Isambard AI](https://www.bristol.ac.uk/research/centres/bristol-supercomputing/#isambard-ai) supercomputer team at Bristol, and the [DAWN](https://www.hpc.cam.ac.uk/d-w-n) supercomputer team at Cambridge, for their generous support in this project. We also acknowledge support from [NVIDIA](https://www.nvidia.com/), [AMD](https://www.amd.com/en.html),  [Vultr](https://www.vultr.com/), the [Dirac High Performance Computing Facility](https://dirac.ac.uk), [Microsoft AI For Good Lab](https://www.microsoft.com/en-us/research/group/ai-for-good-research-lab/), Dr. Robert Sansom, [dClimate](https://www.dclimate.net/), and [Amazon Web Services (AWS)](https://aws.amazon.com/) under their AWS Open Data program (https://opendata.aws/). This work would not have been possible without their support, computational resources and technical assistance.  
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=ucam-eo/tessera&type=Date)](https://www.star-history.com/#ucam-eo/tessera&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ucam-eo/tessera&type=Date)](https://star-history.dera.page/#ucam-eo/tessera&Date)
 
 ## AUP
 


### PR DESCRIPTION
The Star History chart in the README is currently broken because the old service relies on GitHub's stargazer API, which now restricts access. This change moves the chart to a working host so the stargazer chart displays correctly again.